### PR TITLE
fix finalizers name

### DIFF
--- a/pkg/key/key.go
+++ b/pkg/key/key.go
@@ -1,6 +1,6 @@
 package key
 
 const (
-	Finalizer    = "logging-operator.finalizers.giantswarm.io"
+	Finalizer    = "giantswarm.io/logging-operator"
 	LoggingLabel = "giantswarm.io/logging"
 )


### PR DESCRIPTION
On `gauss` MC we had these errors:
```
"error": "Service \"kubernetes\" is invalid: metadata.finalizers[0]: Invalid value: \"logging-operator.finalizers.giantswarm.io\": name is neither a standard finalizer name nor 
is it fully qualified", "errorVerbose": "Service \"kubernetes\" is invalid: metadata.finalizers[0]: Invalid value: \"logging-operator.finalizers.giantswarm.io\": name is neither a standard finalizer name nor is it fully qualified\ngithub.
com/giantswarm/logging-operator/pkg/logging-reconciler.(*LoggingReconciler).reconcileCreate
```

This new finalizer name makes it happy.