### PR TITLE
Implement logged-cluster interface

### DIFF
--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -65,10 +65,10 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	logger.Info(fmt.Sprintf("Name %s", cluster.GetName()))
 
-	object := capicluster.Object{
+	loggedCluster := capicluster.Object{
 		Object: cluster,
 	}
-	result, err = r.LoggingReconciler.Reconcile(ctx, object)
+	result, err = r.LoggingReconciler.Reconcile(ctx, loggedCluster)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/internal/controller/cluster_controller.go
+++ b/internal/controller/cluster_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/giantswarm/logging-operator/pkg/capicluster"
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -64,7 +65,10 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	logger.Info(fmt.Sprintf("Name %s", cluster.GetName()))
 
-	result, err = r.LoggingReconciler.Reconcile(ctx, cluster)
+	object := capicluster.Object{
+		Object: cluster,
+	}
+	result, err = r.LoggingReconciler.Reconcile(ctx, object)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/internal/controller/service_controller.go
+++ b/internal/controller/service_controller.go
@@ -78,10 +78,10 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// IsLoggingEnabled for this controller would only check the given flag, while the CAPI controller
 	// would check both the flag and the label.
 
-	object := vintagemc.Object{
+	loggedCluster := vintagemc.Object{
 		Object: service,
 	}
-	result, err = r.LoggingReconciler.Reconcile(ctx, object)
+	result, err = r.LoggingReconciler.Reconcile(ctx, loggedCluster)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/internal/controller/service_controller.go
+++ b/internal/controller/service_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
+	"github.com/giantswarm/logging-operator/pkg/vintagemc"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,7 +78,10 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 	// IsLoggingEnabled for this controller would only check the given flag, while the CAPI controller
 	// would check both the flag and the label.
 
-	result, err = r.LoggingReconciler.Reconcile(ctx, service)
+	object := vintagemc.Object{
+		Object: service,
+	}
+	result, err = r.LoggingReconciler.Reconcile(ctx, object)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/internal/controller/service_controller.go
+++ b/internal/controller/service_controller.go
@@ -70,13 +70,6 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	logger.Info(fmt.Sprintf("Reconciling Management cluster"))
 
-	// TODO(theo): Pass the IsLoggingEnabled function as a parameter into the LoggingReconciler
-	// So we can have different detection logic to enable logging for Vintage MC and CAPI cluster.
-	// On Vintage MC we determine if logging is enabled based on a global installation
-	// level setting which need to be passed as a flag to this operator.
-	// IsLoggingEnabled for this controller would only check the given flag, while the CAPI controller
-	// would check both the flag and the label.
-
 	result, err = r.LoggingReconciler.Reconcile(ctx, service)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)

--- a/internal/controller/service_controller.go
+++ b/internal/controller/service_controller.go
@@ -70,6 +70,13 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (re
 
 	logger.Info(fmt.Sprintf("Reconciling Management cluster"))
 
+	// TODO(theo): Pass the IsLoggingEnabled function as a parameter into the LoggingReconciler
+	// So we can have different detection logic to enable logging for Vintage MC and CAPI cluster.
+	// On Vintage MC we determine if logging is enabled based on a global installation
+	// level setting which need to be passed as a flag to this operator.
+	// IsLoggingEnabled for this controller would only check the given flag, while the CAPI controller
+	// would check both the flag and the label.
+
 	result, err = r.LoggingReconciler.Reconcile(ctx, service)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)

--- a/pkg/capicluster/cluster.go
+++ b/pkg/capicluster/cluster.go
@@ -1,6 +1,8 @@
 package capicluster
 
 import (
+	"fmt"
+
 	"github.com/giantswarm/logging-operator/pkg/key"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -19,4 +21,8 @@ func (o Object) GetLoggingLabel() string {
 
 func (o Object) GetAppsNamespace() string {
 	return o.Object.GetNamespace()
+}
+
+func (o Object) GetAppName(app string) string {
+	return fmt.Sprintf("%s-%s", o.GetName(), app)
 }

--- a/pkg/capicluster/cluster.go
+++ b/pkg/capicluster/cluster.go
@@ -23,6 +23,6 @@ func (o Object) GetAppsNamespace() string {
 	return o.Object.GetNamespace()
 }
 
-func (o Object) GetAppName(app string) string {
+func (o Object) AppConfigName(app string) string {
 	return fmt.Sprintf("%s-%s", o.GetName(), app)
 }

--- a/pkg/capicluster/cluster.go
+++ b/pkg/capicluster/cluster.go
@@ -1,0 +1,22 @@
+package capicluster
+
+import (
+	"github.com/giantswarm/logging-operator/pkg/key"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Object struct {
+	client.Object
+}
+
+func (o Object) GetLoggingLabel() string {
+	labels := o.Object.GetLabels()
+
+	value := labels[key.LoggingLabel]
+
+	return value
+}
+
+func (o Object) GetAppsNamespace() string {
+	return o.Object.GetNamespace()
+}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -4,7 +4,7 @@ import (
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 )
 
-func IsLoggingEnabled(object loggedcluster.Interface) bool {
+func IsLoggingEnabled(lc loggedcluster.Interface) bool {
 
-	return object.GetLoggingLabel() == "true" && object.GetDeletionTimestamp().IsZero()
+	return lc.GetLoggingLabel() == "true" && lc.GetDeletionTimestamp().IsZero()
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,13 +1,10 @@
 package common
 
 import (
-	"github.com/giantswarm/logging-operator/pkg/key"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 )
 
-func IsLoggingEnabled(object client.Object) bool {
-	labels := object.GetLabels()
-	value, ok := labels[key.LoggingLabel]
+func IsLoggingEnabled(object loggedcluster.Interface) bool {
 
-	return ok && value == "true"
+	return object.GetLoggingLabel() == "true" && object.GetDeletionTimestamp().IsZero()
 }

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -6,5 +6,10 @@ import (
 
 func IsLoggingEnabled(lc loggedcluster.Interface) bool {
 
+	// Logging should be enabled when all conditions are met:
+	//   - logging label is set and true on the cluster
+	//   - cluster is not being deleted
+	//   - TODO(theo) global logging flag is enabled
+
 	return lc.GetLoggingLabel() == "true" && lc.GetDeletionTimestamp().IsZero()
 }

--- a/pkg/logged-cluster/interface.go
+++ b/pkg/logged-cluster/interface.go
@@ -6,5 +6,5 @@ type Interface interface {
 	client.Object
 	GetLoggingLabel() string
 	GetAppsNamespace() string
-	GetAppName(app string) string
+	AppConfigName(app string) string
 }

--- a/pkg/logged-cluster/interface.go
+++ b/pkg/logged-cluster/interface.go
@@ -6,4 +6,5 @@ type Interface interface {
 	client.Object
 	GetLoggingLabel() string
 	GetAppsNamespace() string
+	GetAppName(app string) string
 }

--- a/pkg/logged-cluster/interface.go
+++ b/pkg/logged-cluster/interface.go
@@ -1,0 +1,9 @@
+package loggedcluster
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+type Interface interface {
+	client.Object
+	GetLoggingLabel() string
+	GetAppsNamespace() string
+}

--- a/pkg/logging-reconciler/logging_reconciler.go
+++ b/pkg/logging-reconciler/logging_reconciler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	clusterhelpers "github.com/giantswarm/logging-operator/pkg/cluster-helpers"
+	"github.com/giantswarm/logging-operator/pkg/common"
 	"github.com/giantswarm/logging-operator/pkg/key"
 	"github.com/giantswarm/logging-operator/pkg/reconciler"
 	"github.com/pkg/errors"

--- a/pkg/logging-reconciler/logging_reconciler.go
+++ b/pkg/logging-reconciler/logging_reconciler.go
@@ -24,10 +24,7 @@ type LoggingReconciler struct {
 }
 
 func (l *LoggingReconciler) Reconcile(ctx context.Context, lc loggedcluster.Interface) (result ctrl.Result, err error) {
-	// Logging should be enabled when all conditions are met:
-	//   - logging label is set and true on the lc
-	//   - lc is not being deleted
-	//   - TODO(theo) global logging flag is enabled
+
 	loggingEnabled := common.IsLoggingEnabled(lc)
 
 	if loggingEnabled {

--- a/pkg/logging-reconciler/logging_reconciler.go
+++ b/pkg/logging-reconciler/logging_reconciler.go
@@ -59,6 +59,8 @@ func (l *LoggingReconciler) reconcileCreate(ctx context.Context, object client.O
 		if err != nil {
 			return ctrl.Result{}, errors.WithStack(err)
 		}
+	} else {
+		logger.Info(fmt.Sprintf("finalizer already added"))
 	}
 
 	// Call all reconcilers ReconcileCreate methods.
@@ -96,6 +98,8 @@ func (l *LoggingReconciler) reconcileDelete(ctx context.Context, object client.O
 		if err != nil {
 			return ctrl.Result{}, errors.WithStack(err)
 		}
+	} else {
+		logger.Info(fmt.Sprintf("finalizer already removed"))
 	}
 
 	return ctrl.Result{}, nil

--- a/pkg/logging-reconciler/logging_reconciler.go
+++ b/pkg/logging-reconciler/logging_reconciler.go
@@ -23,15 +23,14 @@ type LoggingReconciler struct {
 }
 
 func (l *LoggingReconciler) Reconcile(ctx context.Context, object client.Object) (result ctrl.Result, err error) {
-
-	// Logging should be disable in case:
-	//   - logging is disabled via a label on the Cluster object
-	//   - Cluster object is being deleted
-	loggingEnabled := clusterhelpers.IsLoggingEnabled(object) && object.GetDeletionTimestamp().IsZero()
+	// Logging should be enabled when all conditions are met:
+	//   - logging label is set and true on the object
+	//   - object is not being deleted
+	//   - TODO(theo) global logging flag is enabled
+	loggingEnabled := common.IsLoggingEnabled(object) && object.GetDeletionTimestamp().IsZero()
 
 	if loggingEnabled {
-
-		// TODO: manage result
+		// TODO: handle returned ctrl.Result
 		_, err = l.reconcileCreate(ctx, object)
 		if err != nil {
 			return ctrl.Result{}, errors.WithStack(err)

--- a/pkg/logging-reconciler/logging_reconciler.go
+++ b/pkg/logging-reconciler/logging_reconciler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/giantswarm/logging-operator/pkg/common"
 	"github.com/giantswarm/logging-operator/pkg/key"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	"github.com/giantswarm/logging-operator/pkg/reconciler"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,12 +23,12 @@ type LoggingReconciler struct {
 	Reconcilers []reconciler.Interface
 }
 
-func (l *LoggingReconciler) Reconcile(ctx context.Context, object client.Object) (result ctrl.Result, err error) {
+func (l *LoggingReconciler) Reconcile(ctx context.Context, object loggedcluster.Interface) (result ctrl.Result, err error) {
 	// Logging should be enabled when all conditions are met:
 	//   - logging label is set and true on the object
 	//   - object is not being deleted
 	//   - TODO(theo) global logging flag is enabled
-	loggingEnabled := common.IsLoggingEnabled(object) && object.GetDeletionTimestamp().IsZero()
+	loggingEnabled := common.IsLoggingEnabled(object)
 
 	if loggingEnabled {
 		// TODO: handle returned ctrl.Result
@@ -46,7 +47,7 @@ func (l *LoggingReconciler) Reconcile(ctx context.Context, object client.Object)
 }
 
 // reconcileCreate handles creation/update logic by calling ReconcileCreate method on all l.Reconcilers.
-func (l *LoggingReconciler) reconcileCreate(ctx context.Context, object client.Object) (ctrl.Result, error) {
+func (l *LoggingReconciler) reconcileCreate(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("LOGGING enabled")
 
@@ -76,7 +77,7 @@ func (l *LoggingReconciler) reconcileCreate(ctx context.Context, object client.O
 }
 
 // reconcileDelete handles deletion logic by calling reconcileDelete method on all l.Reconcilers.
-func (l *LoggingReconciler) reconcileDelete(ctx context.Context, object client.Object) (ctrl.Result, error) {
+func (l *LoggingReconciler) reconcileDelete(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("LOGGING disabled")
 

--- a/pkg/reconciler/interface.go
+++ b/pkg/reconciler/interface.go
@@ -3,8 +3,8 @@ package reconciler
 import (
 	"context"
 
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Interface provides a reconciler interface which is the controller core logic
@@ -14,7 +14,7 @@ import (
 //
 // NOTE: the returned ctrl.Result is currently ignored
 type Interface interface {
-	ReconcileCreate(ctx context.Context, object client.Object) (ctrl.Result, error)
+	ReconcileCreate(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error)
 
-	ReconcileDelete(ctx context.Context, object client.Object) (ctrl.Result, error)
+	ReconcileDelete(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error)
 }

--- a/pkg/reconciler/interface.go
+++ b/pkg/reconciler/interface.go
@@ -14,7 +14,7 @@ import (
 //
 // NOTE: the returned ctrl.Result is currently ignored
 type Interface interface {
-	ReconcileCreate(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error)
+	ReconcileCreate(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error)
 
-	ReconcileDelete(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error)
+	ReconcileDelete(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error)
 }

--- a/pkg/resource/promtail-toggle/observability_bundle_configmap.go
+++ b/pkg/resource/promtail-toggle/observability_bundle_configmap.go
@@ -1,8 +1,6 @@
 package promtailtoggle
 
 import (
-	"fmt"
-
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -21,7 +19,7 @@ type app struct {
 // ObservabilityBundleConfigMapMeta returns metadata for the observability bundle user value configmap.
 func ObservabilityBundleConfigMapMeta(object loggedcluster.Interface) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      fmt.Sprintf("%s-observability-bundle-user-values", object.GetName()),
+		Name:      object.GetAppName("observability-bundle-user-values"),
 		Namespace: object.GetAppsNamespace(),
 	}
 }

--- a/pkg/resource/promtail-toggle/observability_bundle_configmap.go
+++ b/pkg/resource/promtail-toggle/observability_bundle_configmap.go
@@ -17,16 +17,16 @@ type app struct {
 }
 
 // ObservabilityBundleConfigMapMeta returns metadata for the observability bundle user value configmap.
-func ObservabilityBundleConfigMapMeta(object loggedcluster.Interface) metav1.ObjectMeta {
+func ObservabilityBundleConfigMapMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      object.GetAppName("observability-bundle-user-values"),
-		Namespace: object.GetAppsNamespace(),
+		Name:      lc.GetAppName("observability-bundle-user-values"),
+		Namespace: lc.GetAppsNamespace(),
 	}
 }
 
 // GenerateObservabilityBundleConfigMap returns a configmap for
 // the observabilitybundle application to enable promtail.
-func GenerateObservabilityBundleConfigMap(object loggedcluster.Interface) (v1.ConfigMap, error) {
+func GenerateObservabilityBundleConfigMap(lc loggedcluster.Interface) (v1.ConfigMap, error) {
 	values := Values{
 		Apps: map[string]app{
 			"promtail-app": {
@@ -41,7 +41,7 @@ func GenerateObservabilityBundleConfigMap(object loggedcluster.Interface) (v1.Co
 	}
 
 	configmap := v1.ConfigMap{
-		ObjectMeta: ObservabilityBundleConfigMapMeta(object),
+		ObjectMeta: ObservabilityBundleConfigMapMeta(lc),
 		Data: map[string]string{
 			"values": string(v),
 		},

--- a/pkg/resource/promtail-toggle/observability_bundle_configmap.go
+++ b/pkg/resource/promtail-toggle/observability_bundle_configmap.go
@@ -3,10 +3,10 @@ package promtailtoggle
 import (
 	"fmt"
 
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
 
@@ -19,16 +19,16 @@ type app struct {
 }
 
 // ObservabilityBundleConfigMapMeta returns metadata for the observability bundle user value configmap.
-func ObservabilityBundleConfigMapMeta(object client.Object) metav1.ObjectMeta {
+func ObservabilityBundleConfigMapMeta(object loggedcluster.Interface) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:      fmt.Sprintf("%s-observability-bundle-user-values", object.GetName()),
-		Namespace: object.GetName(),
+		Namespace: object.GetAppsNamespace(),
 	}
 }
 
 // GenerateObservabilityBundleConfigMap returns a configmap for
 // the observabilitybundle application to enable promtail.
-func GenerateObservabilityBundleConfigMap(object client.Object) (v1.ConfigMap, error) {
+func GenerateObservabilityBundleConfigMap(object loggedcluster.Interface) (v1.ConfigMap, error) {
 	values := Values{
 		Apps: map[string]app{
 			"promtail-app": {

--- a/pkg/resource/promtail-toggle/observability_bundle_configmap.go
+++ b/pkg/resource/promtail-toggle/observability_bundle_configmap.go
@@ -19,7 +19,7 @@ type app struct {
 // ObservabilityBundleConfigMapMeta returns metadata for the observability bundle user value configmap.
 func ObservabilityBundleConfigMapMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      lc.GetAppName("observability-bundle-user-values"),
+		Name:      lc.AppConfigName("observability-bundle-user-values"),
 		Namespace: lc.GetAppsNamespace(),
 	}
 }

--- a/pkg/resource/promtail-toggle/reconciler.go
+++ b/pkg/resource/promtail-toggle/reconciler.go
@@ -25,12 +25,12 @@ type Reconciler struct {
 }
 
 // ReconcileCreate ensure Promtail is enabled in the given cluster.
-func (r *Reconciler) ReconcileCreate(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error) {
+func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("promtailtoggle create")
 
 	// Get desired configmap to enable promtail.
-	desiredConfigMap, err := GenerateObservabilityBundleConfigMap(object)
+	desiredConfigMap, err := GenerateObservabilityBundleConfigMap(lc)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}
@@ -67,12 +67,12 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, object loggedcluster.I
 }
 
 // ReconcileDelete ensure Promtail is disabled for the given cluster.
-func (r *Reconciler) ReconcileDelete(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error) {
+func (r *Reconciler) ReconcileDelete(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("promtailtoggle delete")
 
 	// Get expected configmap.
-	desiredConfigMap, err := GenerateObservabilityBundleConfigMap(object)
+	desiredConfigMap, err := GenerateObservabilityBundleConfigMap(lc)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/promtail-toggle/reconciler.go
+++ b/pkg/resource/promtail-toggle/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -24,7 +25,7 @@ type Reconciler struct {
 }
 
 // ReconcileCreate ensure Promtail is enabled in the given cluster.
-func (r *Reconciler) ReconcileCreate(ctx context.Context, object client.Object) (ctrl.Result, error) {
+func (r *Reconciler) ReconcileCreate(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("promtailtoggle create")
 
@@ -66,7 +67,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, object client.Object) 
 }
 
 // ReconcileDelete ensure Promtail is disabled for the given cluster.
-func (r *Reconciler) ReconcileDelete(ctx context.Context, object client.Object) (ctrl.Result, error) {
+func (r *Reconciler) ReconcileDelete(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("promtailtoggle delete")
 

--- a/pkg/resource/promtail-wiring/observability_bundle_app.go
+++ b/pkg/resource/promtail-wiring/observability_bundle_app.go
@@ -1,8 +1,6 @@
 package promtailwiring
 
 import (
-	"fmt"
-
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -10,7 +8,7 @@ import (
 // ObservabilityBundleAppMeta returns metadata for the observability bundle app.
 func ObservabilityBundleAppMeta(object loggedcluster.Interface) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      fmt.Sprintf("%s-observability-bundle", object.GetName()),
-		Namespace: object.GetNamespace(),
+		Name:      object.GetAppName("observability-bundle"),
+		Namespace: object.GetAppsNamespace(),
 	}
 }

--- a/pkg/resource/promtail-wiring/observability_bundle_app.go
+++ b/pkg/resource/promtail-wiring/observability_bundle_app.go
@@ -3,14 +3,14 @@ package promtailwiring
 import (
 	"fmt"
 
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ObservabilityBundleAppMeta returns metadata for the observability bundle app.
-func ObservabilityBundleAppMeta(object client.Object) metav1.ObjectMeta {
+func ObservabilityBundleAppMeta(object loggedcluster.Interface) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
 		Name:      fmt.Sprintf("%s-observability-bundle", object.GetName()),
-		Namespace: object.GetName(),
+		Namespace: object.GetNamespace(),
 	}
 }

--- a/pkg/resource/promtail-wiring/observability_bundle_app.go
+++ b/pkg/resource/promtail-wiring/observability_bundle_app.go
@@ -8,7 +8,7 @@ import (
 // ObservabilityBundleAppMeta returns metadata for the observability bundle app.
 func ObservabilityBundleAppMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      lc.GetAppName("observability-bundle"),
+		Name:      lc.AppConfigName("observability-bundle"),
 		Namespace: lc.GetAppsNamespace(),
 	}
 }

--- a/pkg/resource/promtail-wiring/observability_bundle_app.go
+++ b/pkg/resource/promtail-wiring/observability_bundle_app.go
@@ -6,9 +6,9 @@ import (
 )
 
 // ObservabilityBundleAppMeta returns metadata for the observability bundle app.
-func ObservabilityBundleAppMeta(object loggedcluster.Interface) metav1.ObjectMeta {
+func ObservabilityBundleAppMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      object.GetAppName("observability-bundle"),
-		Namespace: object.GetAppsNamespace(),
+		Name:      lc.GetAppName("observability-bundle"),
+		Namespace: lc.GetAppsNamespace(),
 	}
 }

--- a/pkg/resource/promtail-wiring/reconciler.go
+++ b/pkg/resource/promtail-wiring/reconciler.go
@@ -38,10 +38,6 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, object client.Object) 
 	var currentApp appv1.App
 	err := r.Client.Get(ctx, types.NamespacedName{Name: appMeta.GetName(), Namespace: appMeta.GetNamespace()}, &currentApp)
 	if err != nil {
-		// Handle case where the app is not found.
-		if apimachineryerrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 

--- a/pkg/resource/promtail-wiring/reconciler.go
+++ b/pkg/resource/promtail-wiring/reconciler.go
@@ -38,6 +38,10 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, object client.Object) 
 	var currentApp appv1.App
 	err := r.Client.Get(ctx, types.NamespacedName{Name: appMeta.GetName(), Namespace: appMeta.GetNamespace()}, &currentApp)
 	if err != nil {
+		// Handle case where the app is not found.
+		if apimachineryerrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 

--- a/pkg/resource/promtail-wiring/reconciler.go
+++ b/pkg/resource/promtail-wiring/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	appv1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	promtailtoggle "github.com/giantswarm/logging-operator/pkg/resource/promtail-toggle"
 	"github.com/pkg/errors"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,7 +27,7 @@ type Reconciler struct {
 
 // ReconcileCreate ensure user value configmap is set in observability bundle
 // for the given cluster.
-func (r *Reconciler) ReconcileCreate(ctx context.Context, object client.Object) (ctrl.Result, error) {
+func (r *Reconciler) ReconcileCreate(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("promtailwiring create")
 
@@ -34,7 +35,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, object client.Object) 
 	appMeta := ObservabilityBundleAppMeta(object)
 
 	// Retrieve the app.
-	logger.Info(fmt.Sprintf("promtailwiring checking %s/%s", appMeta.GetNamespace(), appMeta.GetNamespace()))
+	logger.Info(fmt.Sprintf("promtailwiring checking %s/%s", appMeta.GetNamespace(), appMeta.GetName()))
 	var currentApp appv1.App
 	err := r.Client.Get(ctx, types.NamespacedName{Name: appMeta.GetName(), Namespace: appMeta.GetNamespace()}, &currentApp)
 	if err != nil {
@@ -58,7 +59,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, object client.Object) 
 
 // ReconcileCreate ensure user value configmap is unset in observability bundle
 // for the given cluster.
-func (r *Reconciler) ReconcileDelete(ctx context.Context, object client.Object) (ctrl.Result, error) {
+func (r *Reconciler) ReconcileDelete(ctx context.Context, object loggedcluster.Interface) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("promtailwiring delete")
 
@@ -93,7 +94,7 @@ func (r *Reconciler) ReconcileDelete(ctx context.Context, object client.Object) 
 
 // setUserConfig set the user value confimap in the app.
 // It returns true in case something was changed.
-func setUserConfig(app *appv1.App, object client.Object) bool {
+func setUserConfig(app *appv1.App, object loggedcluster.Interface) bool {
 	observabilityBundleConfigMapMeta := promtailtoggle.ObservabilityBundleConfigMapMeta(object)
 	updated := app.Spec.UserConfig.ConfigMap.Name != observabilityBundleConfigMapMeta.GetName() || app.Spec.UserConfig.ConfigMap.Namespace != observabilityBundleConfigMapMeta.GetNamespace()
 
@@ -105,7 +106,7 @@ func setUserConfig(app *appv1.App, object client.Object) bool {
 
 // unsetUserConfig unset the user value confimap in the app.
 // It returns true in case something was changed.
-func unsetUserConfig(app *appv1.App, object client.Object) bool {
+func unsetUserConfig(app *appv1.App, object loggedcluster.Interface) bool {
 	observabilityBundleConfigMapMeta := promtailtoggle.ObservabilityBundleConfigMapMeta(object)
 	updated := app.Spec.UserConfig.ConfigMap.Name == observabilityBundleConfigMapMeta.GetName() || app.Spec.UserConfig.ConfigMap.Namespace == observabilityBundleConfigMapMeta.GetNamespace()
 

--- a/pkg/resource/promtail-wiring/reconciler.go
+++ b/pkg/resource/promtail-wiring/reconciler.go
@@ -35,7 +35,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, object loggedcluster.I
 	appMeta := ObservabilityBundleAppMeta(object)
 
 	// Retrieve the app.
-	logger.Info(fmt.Sprintf("promtailwiring checking %s/%s", appMeta.GetNamespace(), appMeta.GetName()))
+	logger.Info(fmt.Sprintf("promtailwiring checking app %s/%s", appMeta.GetNamespace(), appMeta.GetName()))
 	var currentApp appv1.App
 	err := r.Client.Get(ctx, types.NamespacedName{Name: appMeta.GetName(), Namespace: appMeta.GetNamespace()}, &currentApp)
 	if err != nil {

--- a/pkg/vintagemc/cluster.go
+++ b/pkg/vintagemc/cluster.go
@@ -16,6 +16,6 @@ func (o Object) GetAppsNamespace() string {
 	return "giantswarm"
 }
 
-func (o Object) GetAppName(app string) string {
+func (o Object) AppConfigName(app string) string {
 	return app
 }

--- a/pkg/vintagemc/cluster.go
+++ b/pkg/vintagemc/cluster.go
@@ -1,0 +1,17 @@
+package vintagemc
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Object struct {
+	client.Object
+}
+
+func (o Object) GetLoggingLabel() string {
+	return "true"
+}
+
+func (o Object) GetAppsNamespace() string {
+	return "giantswarm"
+}

--- a/pkg/vintagemc/cluster.go
+++ b/pkg/vintagemc/cluster.go
@@ -15,3 +15,7 @@ func (o Object) GetLoggingLabel() string {
 func (o Object) GetAppsNamespace() string {
 	return "giantswarm"
 }
+
+func (o Object) GetAppName(app string) string {
+	return app
+}

--- a/pkg/vintagewc/cluster.go
+++ b/pkg/vintagewc/cluster.go
@@ -1,0 +1,22 @@
+package vintagewc
+
+import (
+	"github.com/giantswarm/logging-operator/pkg/key"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Object struct {
+	client.Object
+}
+
+func (o Object) GetLoggingLabel() string {
+	labels := o.Object.GetLabels()
+
+	value := labels[key.LoggingLabel]
+
+	return value
+}
+
+func (o Object) GetAppsNamespace() string {
+	return o.Object.GetName()
+}

--- a/pkg/vintagewc/cluster.go
+++ b/pkg/vintagewc/cluster.go
@@ -21,6 +21,6 @@ func (o Object) GetAppsNamespace() string {
 	return o.Object.GetName()
 }
 
-func (o Object) GetAppName(app string) string {
+func (o Object) AppConfigName(app string) string {
 	return app
 }

--- a/pkg/vintagewc/cluster.go
+++ b/pkg/vintagewc/cluster.go
@@ -20,3 +20,7 @@ func (o Object) GetLoggingLabel() string {
 func (o Object) GetAppsNamespace() string {
 	return o.Object.GetName()
 }
+
+func (o Object) GetAppName(app string) string {
+	return app
+}


### PR DESCRIPTION
Implement a `logged-cluster` interface with 3 implementations:
- capicluster
- vintagewc
- vintagemc

And let's try to keep the minimum amount of code in these, to limit specific code.