### PR TITLE
add --vintage toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add controller for Vintage Management Cluster via corev1.Service
 - Add controller for Cluster API, cluster.x-k8s.io/v1beta1
 - Add operator basics with kubebuilder
+- Add '--vintage' toggle
 
 [Unreleased]: https://github.com/giantswarm/logging-operator/tree/master


### PR DESCRIPTION
We need a different set of reconcilers running on vintage and CAPI clusters.
So we'll have a CLI flag to select which mode we want when running the logging-operator.