### PR TITLE
add support for extravalues where supported

### DIFF
--- a/pkg/capicluster/cluster.go
+++ b/pkg/capicluster/cluster.go
@@ -30,3 +30,8 @@ func (o Object) AppConfigName(app string) string {
 func (o Object) GetObject() client.Object {
 	return o.Object
 }
+
+// On capi clusters, use an extraconfig
+func (o Object) GetObservabilityBundleConfigMap() string {
+	return "observability-bundle-logging-values"
+}

--- a/pkg/logged-cluster/interface.go
+++ b/pkg/logged-cluster/interface.go
@@ -8,4 +8,5 @@ type Interface interface {
 	GetAppsNamespace() string
 	AppConfigName(app string) string
 	GetObject() client.Object
+	GetObservabilityBundleConfigMap() string
 }

--- a/pkg/resource/promtail-toggle/observability_bundle_configmap.go
+++ b/pkg/resource/promtail-toggle/observability_bundle_configmap.go
@@ -16,11 +16,15 @@ type app struct {
 	Enabled bool `yaml:"enabled" json:"enabled"`
 }
 
-// ObservabilityBundleConfigMapMeta returns metadata for the observability bundle user value configmap.
+// ObservabilityBundleConfigMapMeta returns metadata for the observability bundle extra values configmap.
 func ObservabilityBundleConfigMapMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      lc.AppConfigName("observability-bundle-user-values"),
+		Name:      lc.AppConfigName(lc.GetObservabilityBundleConfigMap()),
 		Namespace: lc.GetAppsNamespace(),
+		Labels: map[string]string{
+			// This label is used by cluster-operator to find extraconfig
+			"app.kubernetes.io/name": lc.AppConfigName("observability-bundle"),
+		},
 	}
 }
 

--- a/pkg/vintagemc/cluster.go
+++ b/pkg/vintagemc/cluster.go
@@ -23,3 +23,8 @@ func (o Object) AppConfigName(app string) string {
 func (o Object) GetObject() client.Object {
 	return o.Object
 }
+
+// On vintage MC, there's no support for extraconfig so we should use standard user values
+func (o Object) GetObservabilityBundleConfigMap() string {
+	return "observability-bundle-user-values"
+}

--- a/pkg/vintagewc/cluster.go
+++ b/pkg/vintagewc/cluster.go
@@ -28,3 +28,8 @@ func (o Object) AppConfigName(app string) string {
 func (o Object) GetObject() client.Object {
 	return o.Object
 }
+
+// on vintage WC, use extraconfig
+func (o Object) GetObservabilityBundleConfigMap() string {
+	return "observability-bundle-logging-values"
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27146

We should not overwrite user config for WCs, as some customers set some custom ones.
So we decided to go for extra-configs.

But when discussing with @QuentinBisson yesterday, we understood that:
- vintage MCs don't support extraconfig because they're not reconciled by cluster-operator
- for capi clusters we're not sure

So I did this dirty thing that will work at least on vintage.
To be discussed.