### PR TITLE
add grafana datasource

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/giantswarm/logging-operator/internal/controller"
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
 	"github.com/giantswarm/logging-operator/pkg/reconciler"
+	grafanadatasource "github.com/giantswarm/logging-operator/pkg/resource/grafana-datasource"
 	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 	promtailtoggle "github.com/giantswarm/logging-operator/pkg/resource/promtail-toggle"
 	promtailwiring "github.com/giantswarm/logging-operator/pkg/resource/promtail-wiring"
@@ -113,6 +114,10 @@ func main() {
 		Client: mgr.GetClient(),
 	}
 
+	grafanaDatasource := grafanadatasource.Reconciler{
+		Client: mgr.GetClient(),
+	}
+
 	loggingReconciler := loggingreconciler.LoggingReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
@@ -120,6 +125,7 @@ func main() {
 			&promtailReconciler,
 			&promtailWiring,
 			&loggingSecrets,
+			&grafanaDatasource,
 		},
 	}
 

--- a/pkg/resource/grafana-datasource/grafana-loki-datasource.go
+++ b/pkg/resource/grafana-datasource/grafana-loki-datasource.go
@@ -44,8 +44,8 @@ type secureJsonData struct {
 	BasicAuthPassword string `yaml:"basicAuthPassword" json:"basicAuthPassword"`
 }
 
-// ObservabilityBundleConfigMapMeta returns metadata for the observability bundle extra values configmap.
-func DatasourceConfigMapMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
+// DatasourceSecretMeta returns metadata for the observability bundle extra values configmap.
+func DatasourceSecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 	metadata := metav1.ObjectMeta{
 		Name:      datasourceSecretName,
 		Namespace: datasourceSecretNamespace,
@@ -72,7 +72,6 @@ func GenerateDatasourceSecret(lc loggedcluster.Interface, credentialsSecret *v1.
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
 	}
-	// password = base64.StdEncoding.EncodeToString([]byte(password))
 
 	values := Values{
 		ApiVersion: 1,
@@ -101,7 +100,7 @@ func GenerateDatasourceSecret(lc loggedcluster.Interface, credentialsSecret *v1.
 	}
 
 	secret := v1.Secret{
-		ObjectMeta: DatasourceConfigMapMeta(lc),
+		ObjectMeta: DatasourceSecretMeta(lc),
 		Data: map[string][]byte{
 			"datasource.yaml": []byte(v),
 		},

--- a/pkg/resource/grafana-datasource/grafana-loki-datasource.go
+++ b/pkg/resource/grafana-datasource/grafana-loki-datasource.go
@@ -12,6 +12,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	lokiURL                   = "http://loki-gateway.loki.svc.cluster.local"
+	datasourceName            = "Loki"
+	datasourceSecretName      = "loki-datasource"
+	datasourceSecretNamespace = "monitoring"
+)
+
 type Values struct {
 	ApiVersion  int          `yaml:"apiversion" json:"apiversion"`
 	Datasources []datasource `yaml:"datasources" json:"datasources"`
@@ -40,8 +47,8 @@ type secureJsonData struct {
 // ObservabilityBundleConfigMapMeta returns metadata for the observability bundle extra values configmap.
 func DatasourceConfigMapMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 	metadata := metav1.ObjectMeta{
-		Name:      "loki-datasource",
-		Namespace: "monitoring",
+		Name:      datasourceSecretName,
+		Namespace: datasourceSecretNamespace,
 		Labels: map[string]string{
 			// This label is used to detect datasources
 			"app.giantswarm.io/kind": "datasource",
@@ -78,9 +85,9 @@ func GenerateDatasourceSecret(lc loggedcluster.Interface, credentialsSecret *v1.
 				JsonData: jsonData{
 					ManageAlerts: false,
 				},
-				Name: "Lokitest",
+				Name: datasourceName,
 				Type: "loki",
-				Url:  "http://loki-gateway.loki.svc.cluster.local",
+				Url:  lokiURL,
 				SecureJsonData: secureJsonData{
 					BasicAuthPassword: base64.StdEncoding.EncodeToString([]byte(password)),
 				},

--- a/pkg/resource/grafana-datasource/grafana-loki-datasource.go
+++ b/pkg/resource/grafana-datasource/grafana-loki-datasource.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	lokiURL                   = "http://loki-gateway.loki.svc.cluster.local"
+	lokiURL                   = "http://loki-gateway.loki.svc"
 	datasourceName            = "Loki"
 	datasourceSecretName      = "loki-datasource"
 	datasourceSecretNamespace = "monitoring"

--- a/pkg/resource/grafana-datasource/reconciler.go
+++ b/pkg/resource/grafana-datasource/reconciler.go
@@ -1,0 +1,86 @@
+package grafanadatasource
+
+import (
+	"context"
+	"reflect"
+
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Reconciler implements a reconciler.Interface to handle
+// Promtail toggle: enable or disable Promtail in a given Cluster.
+type Reconciler struct {
+	client.Client
+}
+
+// ReconcileCreate ensures Grafana Datasource for Loki is created with the right credentials
+func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("grafanadatasource create")
+
+	// Retrieve secret containing credentials
+	var loggingCredentialsSecret v1.Secret
+	err := r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
+		&loggingCredentialsSecret)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	// Get desired secret
+	desiredDatasourceSecret, err := GenerateDatasourceSecret(lc, &loggingCredentialsSecret)
+	if err != nil {
+		logger.Info("grafanadatasource - failed generating Datasource!", "error", err)
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	// Check if datasource already exists.
+	logger.Info("grafanadatasource - getting", "namespace", desiredDatasourceSecret.GetNamespace(), "name", desiredDatasourceSecret.GetName())
+	var currentDatasourceSecret v1.Secret
+	err = r.Client.Get(ctx, types.NamespacedName{Name: desiredDatasourceSecret.GetName(), Namespace: desiredDatasourceSecret.GetNamespace()}, &currentDatasourceSecret)
+	if err != nil {
+		if apimachineryerrors.IsNotFound(err) {
+			logger.Info("grafanadatasource not found, creating")
+			err = r.Client.Create(ctx, &desiredDatasourceSecret)
+			if err != nil {
+				return ctrl.Result{}, errors.WithStack(err)
+			}
+		} else {
+			return ctrl.Result{}, errors.WithStack(err)
+		}
+	}
+
+	if !needUpdate(currentDatasourceSecret, desiredDatasourceSecret) {
+		logger.Info("grafanadatasource up to date")
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("grafanadatasource - updating")
+	err = r.Client.Update(ctx, &desiredDatasourceSecret)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// ReconcileDelete - Not much to do here when a cluster is deleted
+func (r *Reconciler) ReconcileDelete(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("grafanadatasource delete")
+
+	return ctrl.Result{}, nil
+}
+
+// needUpdate return true if current.Data and desired.Data do not match.
+func needUpdate(current, desired v1.Secret) bool {
+	return !reflect.DeepEqual(current.Data, desired.Data)
+}

--- a/pkg/resource/logging-credentials/logging_operator_secrets.go
+++ b/pkg/resource/logging-credentials/logging_operator_secrets.go
@@ -4,6 +4,10 @@ import (
 	"crypto/rand"
 	"math/big"
 
+	"fmt"
+
+	"github.com/pkg/errors"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -53,6 +57,26 @@ func GenerateLoggingCredentialsBasicSecret(lc loggedcluster.Interface) *v1.Secre
 	}
 
 	return &secret
+}
+
+func GetLogin(lc loggedcluster.Interface, credentialsSecret *v1.Secret, user string) (string, error) {
+
+	login, ok := credentialsSecret.Data[fmt.Sprintf("%suser", user)]
+
+	if !ok {
+		return "", errors.New("Not found")
+	}
+	return string(login), nil
+}
+
+func GetPass(lc loggedcluster.Interface, credentialsSecret *v1.Secret, user string) (string, error) {
+
+	pass, ok := credentialsSecret.Data[fmt.Sprintf("%spassword", user)]
+
+	if !ok {
+		return "", errors.New("Not found")
+	}
+	return string(pass), nil
 }
 
 // Update a LoggingCredentials secret if needed


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27146

Creates the DS for now, with read credentials from the logging-credentials.

Remark: maybe it should reconciliate the secret directly, rather than a cluster?