### PR TITLE
create loki-multi-tenant auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/giantswarm/logging-operator/pkg/reconciler"
 	grafanadatasource "github.com/giantswarm/logging-operator/pkg/resource/grafana-datasource"
 	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
+	lokiauth "github.com/giantswarm/logging-operator/pkg/resource/loki-auth"
 	promtailtoggle "github.com/giantswarm/logging-operator/pkg/resource/promtail-toggle"
 	promtailwiring "github.com/giantswarm/logging-operator/pkg/resource/promtail-wiring"
 	//+kubebuilder:scaffold:imports
@@ -118,6 +119,10 @@ func main() {
 		Client: mgr.GetClient(),
 	}
 
+	lokiAuth := lokiauth.Reconciler{
+		Client: mgr.GetClient(),
+	}
+
 	loggingReconciler := loggingreconciler.LoggingReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
@@ -126,6 +131,7 @@ func main() {
 			&promtailWiring,
 			&loggingSecrets,
 			&grafanaDatasource,
+			&lokiAuth,
 		},
 	}
 

--- a/pkg/resource/grafana-datasource/grafana-loki-datasource.go
+++ b/pkg/resource/grafana-datasource/grafana-loki-datasource.go
@@ -3,13 +3,14 @@ package grafanadatasource
 import (
 	"encoding/base64"
 
-	"github.com/giantswarm/logging-operator/pkg/common"
-	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
-	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/logging-operator/pkg/common"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 )
 
 const (

--- a/pkg/resource/grafana-datasource/reconciler.go
+++ b/pkg/resource/grafana-datasource/reconciler.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"reflect"
 
-	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
-	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/resource/loki-auth/loki-auth.go
+++ b/pkg/resource/loki-auth/loki-auth.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	//#nosec G101
 	lokiauthSecretName          = "loki-multi-tenant-proxy-auth-config"
 	lokiauthSecretNamespace     = "loki"
 	lokiauthDeploymentName      = "loki-multi-tenant-proxy"
@@ -101,8 +102,11 @@ func GenerateLokiAuthSecret(lc loggedcluster.Interface, credentialsSecret *v1.Se
 	return secret, nil
 }
 
+// This one is a hack until the proxy knows how to automatically reload its config
 func ReloadLokiProxy(lc loggedcluster.Interface, ctx context.Context, client client.Client) error {
 	const triggerredeployLabel = "app.giantswarm.io/triggerredeploy"
+	const tickValue = "tick"
+	const tockValue = "tock"
 
 	var lokiProxyDeployment appsv1.Deployment
 	err := client.Get(ctx, types.NamespacedName{Name: lokiauthDeploymentName, Namespace: lokiauthDeploymentNamespace}, &lokiProxyDeployment)
@@ -114,14 +118,14 @@ func ReloadLokiProxy(lc loggedcluster.Interface, ctx context.Context, client cli
 
 	if val, ok := labels[triggerredeployLabel]; ok {
 
-		if val == "tick" {
-			labels[triggerredeployLabel] = "tock"
+		if val == tickValue {
+			labels[triggerredeployLabel] = tockValue
 		} else {
-			labels[triggerredeployLabel] = "tick"
+			labels[triggerredeployLabel] = tickValue
 		}
 
 	} else {
-		labels[triggerredeployLabel] = "tick"
+		labels[triggerredeployLabel] = tickValue
 	}
 
 	lokiProxyDeployment.Spec.Template.ObjectMeta.SetLabels(labels)

--- a/pkg/resource/loki-auth/loki-auth.go
+++ b/pkg/resource/loki-auth/loki-auth.go
@@ -1,0 +1,94 @@
+package lokiauth
+
+import (
+	"github.com/giantswarm/logging-operator/pkg/common"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	lokiauthSecretName      = "loki-multi-tenant-proxy-auth-config"
+	lokiauthSecretNamespace = "loki"
+)
+
+type Values struct {
+	Users []user `yaml:"users" json:"users"`
+}
+
+type user struct {
+	Username string `yaml:"username" json:"username"`
+	Password string `yaml:"password" json:"password"`
+	Orgid    string `yaml:"orgid" json:"orgid"`
+}
+
+// LokiConfigSecretMeta returns metadata for the Loki-multi-tenant-proxy secret
+func LokiAuthSecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
+	metadata := metav1.ObjectMeta{
+		Name:      lokiauthSecretName,
+		Namespace: lokiauthSecretNamespace,
+		Labels:    map[string]string{},
+	}
+
+	common.AddCommonLabels(metadata.Labels)
+	return metadata
+}
+
+// GenerateLokiAuthSecret returns a secret for
+// the Loki-multi-tenant-proxy auth config
+func GenerateLokiAuthSecret(lc loggedcluster.Interface, credentialsSecret *v1.Secret) (v1.Secret, error) {
+
+	readUser, err := loggingcredentials.GetLogin(lc, credentialsSecret, "read")
+	if err != nil {
+		return v1.Secret{}, errors.WithStack(err)
+	}
+
+	readPassword, err := loggingcredentials.GetPass(lc, credentialsSecret, "read")
+	if err != nil {
+		return v1.Secret{}, errors.WithStack(err)
+	}
+
+	writeUser, err := loggingcredentials.GetLogin(lc, credentialsSecret, "write")
+	if err != nil {
+		return v1.Secret{}, errors.WithStack(err)
+	}
+
+	writePassword, err := loggingcredentials.GetPass(lc, credentialsSecret, "write")
+	if err != nil {
+		return v1.Secret{}, errors.WithStack(err)
+	}
+
+	values := Values{
+		Users: []user{
+			{
+				Username: readUser,
+				Password: readPassword,
+				// make sure to have at least 2 tenants to prevent writing with this user
+				Orgid: "giantswarm|default",
+			},
+			{
+				Username: writeUser,
+				Password: writePassword,
+				// on the write path the tenant will be given by the sender (promtail)
+				Orgid: "none",
+			},
+		},
+	}
+
+	v, err := yaml.Marshal(values)
+	if err != nil {
+		return v1.Secret{}, errors.WithStack(err)
+	}
+
+	secret := v1.Secret{
+		ObjectMeta: LokiAuthSecretMeta(lc),
+		Data: map[string][]byte{
+			"authn.yaml": []byte(v),
+		},
+	}
+
+	return secret, nil
+}

--- a/pkg/resource/loki-auth/loki-auth.go
+++ b/pkg/resource/loki-auth/loki-auth.go
@@ -3,9 +3,6 @@ package lokiauth
 import (
 	"context"
 
-	"github.com/giantswarm/logging-operator/pkg/common"
-	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
-	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -13,6 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/logging-operator/pkg/common"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 )
 
 const (

--- a/pkg/resource/loki-auth/reconciler.go
+++ b/pkg/resource/loki-auth/reconciler.go
@@ -1,0 +1,88 @@
+package lokiauth
+
+import (
+	"context"
+	"reflect"
+
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Reconciler implements a reconciler.Interface to handle
+// Promtail toggle: enable or disable Promtail in a given Cluster.
+type Reconciler struct {
+	client.Client
+}
+
+// ReconcileCreate ensures Loki-multi-tenant auth map is created with the right credentials
+func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("lokiauth create")
+
+	// Retrieve secret containing credentials
+	var lokiAuthSecret v1.Secret
+	err := r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
+		&lokiAuthSecret)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	// Get desired secret
+	desiredLokiAuthSecret, err := GenerateLokiAuthSecret(lc, &lokiAuthSecret)
+	if err != nil {
+		logger.Info("lokiauth - failed generating auth config!", "error", err)
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	// Check if auth config already exists.
+	logger.Info("lokiauth - getting", "namespace", desiredLokiAuthSecret.GetNamespace(), "name", desiredLokiAuthSecret.GetName())
+	var currentLokiAuthSecret v1.Secret
+	err = r.Client.Get(ctx, types.NamespacedName{Name: desiredLokiAuthSecret.GetName(), Namespace: desiredLokiAuthSecret.GetNamespace()}, &currentLokiAuthSecret)
+	if err != nil {
+		if apimachineryerrors.IsNotFound(err) {
+			logger.Info("lokiauth not found, creating")
+			err = r.Client.Create(ctx, &desiredLokiAuthSecret)
+			if err != nil {
+				return ctrl.Result{}, errors.WithStack(err)
+			}
+		} else {
+			return ctrl.Result{}, errors.WithStack(err)
+		}
+	}
+
+	if !needUpdate(currentLokiAuthSecret, desiredLokiAuthSecret) {
+		logger.Info("lokiauth up to date")
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("lokiauth - updating")
+	err = r.Client.Update(ctx, &desiredLokiAuthSecret)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	// trigger restart of loki-multi-tenant-auth-proxy
+
+	return ctrl.Result{}, nil
+}
+
+// ReconcileDelete - Not much to do here when a cluster is deleted
+func (r *Reconciler) ReconcileDelete(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("lokiauth delete")
+
+	return ctrl.Result{}, nil
+}
+
+// needUpdate return true if current.Data and desired.Data do not match.
+func needUpdate(current, desired v1.Secret) bool {
+	return !reflect.DeepEqual(current.Data, desired.Data)
+}

--- a/pkg/resource/loki-auth/reconciler.go
+++ b/pkg/resource/loki-auth/reconciler.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"reflect"
 
-	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
-	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/resource/loki-auth/reconciler.go
+++ b/pkg/resource/loki-auth/reconciler.go
@@ -69,8 +69,14 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	// trigger restart of loki-multi-tenant-auth-proxy
+	logger.Info("lokiauth - trigger loki-multi-tenant-auth-proxy restart")
 
+	err = ReloadLokiProxy(lc, ctx, r.Client)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	logger.Info("lokiauth - done")
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27146

Creates loki auth config, and trigger recycling of loki-multi-tenant-proxy pods once done.

Relies on #12 for `GetLogin` and `GetPass` functions.