### PR TITLE
remove 'COPY api/' command from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN go mod download
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
-COPY api/ api/
 COPY internal/controller/ internal/controller/
 
 # Build


### PR DESCRIPTION
Remove command from dockerfile as the `api` folder does not exist in the repo and is causing the image build to fail : 
```bash
Step 9/16 : COPY api/ api/
COPY failed: file not found in build context or excluded by .dockerignore: stat api/: file does not exist
```