### PR TITLE
Smallfixes

### DIFF
--- a/pkg/resource/grafana-datasource/grafana-loki-datasource.go
+++ b/pkg/resource/grafana-datasource/grafana-loki-datasource.go
@@ -1,8 +1,6 @@
 package grafanadatasource
 
 import (
-	"encoding/base64"
-
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,10 +16,11 @@ const (
 	datasourceName            = "Loki"
 	datasourceSecretName      = "loki-datasource"
 	datasourceSecretNamespace = "monitoring"
+	datasourceFileName        = "loki-datasource.yaml"
 )
 
 type Values struct {
-	ApiVersion  int          `yaml:"apiversion" json:"apiversion"`
+	ApiVersion  int          `yaml:"apiVersion" json:"apiVersion"`
 	Datasources []datasource `yaml:"datasources" json:"datasources"`
 }
 
@@ -89,7 +88,7 @@ func GenerateDatasourceSecret(lc loggedcluster.Interface, credentialsSecret *v1.
 				Type: "loki",
 				Url:  lokiURL,
 				SecureJsonData: secureJsonData{
-					BasicAuthPassword: base64.StdEncoding.EncodeToString([]byte(password)),
+					BasicAuthPassword: password,
 				},
 			},
 		},
@@ -103,7 +102,7 @@ func GenerateDatasourceSecret(lc loggedcluster.Interface, credentialsSecret *v1.
 	secret := v1.Secret{
 		ObjectMeta: DatasourceSecretMeta(lc),
 		Data: map[string][]byte{
-			"datasource.yaml": []byte(v),
+			datasourceFileName: []byte(v),
 		},
 	}
 

--- a/pkg/resource/logging-credentials/logging_operator_secrets.go
+++ b/pkg/resource/logging-credentials/logging_operator_secrets.go
@@ -38,8 +38,7 @@ func genPassword() (string, error) {
 
 	chars := []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
 		"abcdefghijklmnopqrstuvwxyz" +
-		"0123456789" +
-		"~=+%^*/()[]{}/!@#$?|")
+		"0123456789")
 
 	pass := make([]rune, length)
 	for i := 0; i < length; i++ {

--- a/pkg/resource/logging-credentials/logging_operator_secrets.go
+++ b/pkg/resource/logging-credentials/logging_operator_secrets.go
@@ -15,11 +15,16 @@ import (
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 )
 
+const (
+	LoggingCredentialsName      = "logging-credentials"
+	LoggingCredentialsNamespace = "monitoring"
+)
+
 // LoggingCredentialsSecretMeta returns metadata for the logging-operator credentials secret.
 func LoggingCredentialsSecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 	metadata := metav1.ObjectMeta{
-		Name:      "logging-credentials",
-		Namespace: "monitoring",
+		Name:      LoggingCredentialsName,
+		Namespace: LoggingCredentialsNamespace,
 		Labels:    map[string]string{},
 	}
 


### PR DESCRIPTION
Fix datasource:
* correct spelling for `apiVersion`
* password should not be base64-encoded
* special characters were breaking auth