### PR TITLE
promtailclient reconciler

### DIFF
--- a/internal/controller/capicluster_controller.go
+++ b/internal/controller/capicluster_controller.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/giantswarm/logging-operator/pkg/capicluster"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
 )
 
@@ -66,7 +67,8 @@ func (r *CapiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	logger.Info("Reconciling CAPI Cluster", "name", cluster.GetName())
 
 	loggedCluster := capicluster.Object{
-		Object: cluster,
+		Object:  cluster,
+		Options: loggedcluster.O,
 	}
 	_, err = r.LoggingReconciler.Reconcile(ctx, loggedCluster)
 	if err != nil {

--- a/internal/controller/vintagemc_controller.go
+++ b/internal/controller/vintagemc_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
 	"github.com/giantswarm/logging-operator/pkg/vintagemc"
 )
@@ -79,7 +80,8 @@ func (r *VintageMCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// would check both the flag and the label.
 
 	loggedCluster := vintagemc.Object{
-		Object: service,
+		Object:  service,
+		Options: loggedcluster.O,
 	}
 	_, err = r.LoggingReconciler.Reconcile(ctx, loggedCluster)
 	if err != nil {

--- a/internal/controller/vintagewc_controller.go
+++ b/internal/controller/vintagewc_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
 	"github.com/giantswarm/logging-operator/pkg/vintagewc"
 )
@@ -66,7 +67,8 @@ func (r *VintageWCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger.Info("Reconciling Vintage WV cluster", "name", cluster.GetName())
 
 	loggedCluster := vintagewc.Object{
-		Object: cluster,
+		Object:  cluster,
+		Options: loggedcluster.O,
 	}
 	_, err = r.LoggingReconciler.Reconcile(ctx, loggedCluster)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	appv1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 
 	"github.com/giantswarm/logging-operator/internal/controller"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
 	"github.com/giantswarm/logging-operator/pkg/reconciler"
 	grafanadatasource "github.com/giantswarm/logging-operator/pkg/resource/grafana-datasource"
@@ -130,8 +131,8 @@ func main() {
 		Client: mgr.GetClient(),
 	}
 
-	var loggingReconcilerOptions = make(map[string]string)
-	loggingReconcilerOptions["installName"] = installationName
+	loggedcluster.O.LoggingEnabled = true
+	loggedcluster.O.InstallationName = installationName
 
 	loggingReconciler := loggingreconciler.LoggingReconciler{
 		Client: mgr.GetClient(),

--- a/main.go
+++ b/main.go
@@ -61,14 +61,14 @@ func init() {
 
 func main() {
 	var enableLeaderElection bool
-	var installName string
+	var installationName string
 	var metricsAddr string
 	var probeAddr string
 	var vintageMode bool
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&installName, "install-name", "unknown", "Name of the installation")
+	flag.StringVar(&installationName, "installation-name", "unknown", "Name of the installation")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&vintageMode, "vintage", false, "Reconcile resources on a Vintage installation")
@@ -131,7 +131,7 @@ func main() {
 	}
 
 	var loggingReconcilerOptions = make(map[string]string)
-	loggingReconcilerOptions["installName"] = installName
+	loggingReconcilerOptions["installName"] = installationName
 
 	loggingReconciler := loggingreconciler.LoggingReconciler{
 		Client: mgr.GetClient(),

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	grafanadatasource "github.com/giantswarm/logging-operator/pkg/resource/grafana-datasource"
 	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 	lokiauth "github.com/giantswarm/logging-operator/pkg/resource/loki-auth"
+	promtailclient "github.com/giantswarm/logging-operator/pkg/resource/promtail-client"
 	promtailtoggle "github.com/giantswarm/logging-operator/pkg/resource/promtail-toggle"
 	promtailwiring "github.com/giantswarm/logging-operator/pkg/resource/promtail-wiring"
 	//+kubebuilder:scaffold:imports
@@ -60,12 +61,14 @@ func init() {
 
 func main() {
 	var enableLeaderElection bool
+	var installName string
 	var metricsAddr string
 	var probeAddr string
 	var vintageMode bool
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&installName, "install-name", "unknown", "Name of the installation")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&vintageMode, "vintage", false, "Reconcile resources on a Vintage installation")
@@ -123,6 +126,13 @@ func main() {
 		Client: mgr.GetClient(),
 	}
 
+	promtailClient := promtailclient.Reconciler{
+		Client: mgr.GetClient(),
+	}
+
+	var loggingReconcilerOptions = make(map[string]string)
+	loggingReconcilerOptions["installName"] = installName
+
 	loggingReconciler := loggingreconciler.LoggingReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
@@ -132,6 +142,7 @@ func main() {
 			&loggingSecrets,
 			&grafanaDatasource,
 			&lokiAuth,
+			&promtailClient,
 		},
 	}
 

--- a/pkg/capicluster/cluster.go
+++ b/pkg/capicluster/cluster.go
@@ -28,6 +28,10 @@ func (o Object) AppConfigName(app string) string {
 	return fmt.Sprintf("%s-%s", o.GetName(), app)
 }
 
+func (o Object) GetClusterName() string {
+	return o.Object.GetName()
+}
+
 func (o Object) GetObject() client.Object {
 	return o.Object
 }

--- a/pkg/capicluster/cluster.go
+++ b/pkg/capicluster/cluster.go
@@ -6,10 +6,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/logging-operator/pkg/key"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 )
 
 type Object struct {
 	client.Object
+	Options loggedcluster.Options
 }
 
 func (o Object) GetLoggingLabel() string {
@@ -30,6 +32,10 @@ func (o Object) AppConfigName(app string) string {
 
 func (o Object) GetClusterName() string {
 	return o.Object.GetName()
+}
+
+func (o Object) GetInstallationName() string {
+	return o.Options.InstallationName
 }
 
 func (o Object) GetObject() client.Object {

--- a/pkg/logged-cluster/interface.go
+++ b/pkg/logged-cluster/interface.go
@@ -8,6 +8,7 @@ type Interface interface {
 	GetLoggingLabel() string
 	GetAppsNamespace() string
 	GetClusterName() string
+	GetInstallationName() string
 	AppConfigName(app string) string
 	GetObject() client.Object
 	GetObservabilityBundleConfigMap() string

--- a/pkg/logged-cluster/interface.go
+++ b/pkg/logged-cluster/interface.go
@@ -2,10 +2,12 @@ package loggedcluster
 
 import "sigs.k8s.io/controller-runtime/pkg/client"
 
+// Interface contains the definition of functions that can differ between each type of cluster
 type Interface interface {
 	client.Object
 	GetLoggingLabel() string
 	GetAppsNamespace() string
+	GetClusterName() string
 	AppConfigName(app string) string
 	GetObject() client.Object
 	GetObservabilityBundleConfigMap() string

--- a/pkg/logged-cluster/options.go
+++ b/pkg/logged-cluster/options.go
@@ -1,0 +1,10 @@
+package loggedcluster
+
+// Options to be used for any loggedCluster
+type Options struct {
+	LoggingEnabled   bool
+	InstallationName string
+}
+
+// O blah
+var O = Options{}

--- a/pkg/resource/promtail-client/promtail-client.go
+++ b/pkg/resource/promtail-client/promtail-client.go
@@ -84,7 +84,7 @@ func GeneratePromtailClientSecret(lc loggedcluster.Interface, credentialsSecret 
 		return v1.Secret{}, errors.WithStack(err)
 	}
 
-	installName := "gauss"
+	installationName := lc.GetInstallationName()
 
 	values := values{
 		Promtail: promtail{
@@ -101,7 +101,7 @@ func GeneratePromtailClientSecret(lc loggedcluster.Interface, credentialsSecret 
 							MaxPeriod: "10m",
 						},
 						ExternalLabels: promtailConfigClientExternalLabels{
-							Installation: installName,
+							Installation: installationName,
 							ClusterID:    lc.GetName(),
 						},
 					},

--- a/pkg/resource/promtail-client/promtail-client.go
+++ b/pkg/resource/promtail-client/promtail-client.go
@@ -102,7 +102,7 @@ func GeneratePromtailClientSecret(lc loggedcluster.Interface, credentialsSecret 
 						},
 						ExternalLabels: promtailConfigClientExternalLabels{
 							Installation: installationName,
-							ClusterID:    lc.GetName(),
+							ClusterID:    lc.GetClusterName(),
 						},
 					},
 				},

--- a/pkg/resource/promtail-client/promtail-client.go
+++ b/pkg/resource/promtail-client/promtail-client.go
@@ -1,0 +1,142 @@
+package promtailclient
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/logging-operator/pkg/common"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
+)
+
+const (
+	promtailClientSecretName = "logging-secret"
+	lokiIngressNamespace     = "loki"
+	lokiIngressName          = "loki-gateway"
+)
+
+type values struct {
+	Promtail promtail `yaml:"promtail" json:"promtail"`
+}
+
+type promtail struct {
+	Config promtailConfig `yaml:"config" json:"config"`
+}
+
+type promtailConfig struct {
+	Clients []promtailConfigClient `yaml:"clients" json:"clients"`
+}
+
+// TODO: use upstream promtail structures
+type promtailConfigClient struct {
+	URL            string                             `yaml:"url" json:"url"`
+	TenantID       string                             `yaml:"tenant_id" json:"tenant_id"`
+	BasicAuth      promtailConfigClientBasicAuth      `yaml:"basic_auth" json:"basic_auth"`
+	BackoffConfig  promtailConfigClientBackoffConfig  `yaml:"backoff_config" json:"backoff_config"`
+	ExternalLabels promtailConfigClientExternalLabels `yaml:"external_labels" json:"external_labels"`
+}
+
+type promtailConfigClientExternalLabels struct {
+	Installation string `yaml:"installation" json:"installation"`
+	ClusterID    string `yaml:"cluster_id" json:"cluster_id"`
+}
+
+type promtailConfigClientBackoffConfig struct {
+	MaxPeriod string `yaml:"max_period" json:"max_period"`
+}
+
+type promtailConfigClientBasicAuth struct {
+	Username string `yaml:"username" json:"username"`
+	Password string `yaml:"password" json:"password"`
+}
+
+// SecretMeta returns metadata for the promtail-user-secrets
+func SecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
+	metadata := metav1.ObjectMeta{
+		Name:      fmt.Sprintf("%s-%s", lc.GetClusterName(), promtailClientSecretName),
+		Namespace: lc.GetAppsNamespace(),
+		Labels:    map[string]string{},
+	}
+
+	common.AddCommonLabels(metadata.Labels)
+	return metadata
+}
+
+// GeneratePromtailClientSecret returns a secret for
+// the Loki-multi-tenant-proxy auth config
+func GeneratePromtailClientSecret(lc loggedcluster.Interface, credentialsSecret *v1.Secret, lokiURL string) (v1.Secret, error) {
+
+	writeUser, err := loggingcredentials.GetLogin(lc, credentialsSecret, "write")
+	if err != nil {
+		return v1.Secret{}, errors.WithStack(err)
+	}
+
+	writePassword, err := loggingcredentials.GetPass(lc, credentialsSecret, "write")
+	if err != nil {
+		return v1.Secret{}, errors.WithStack(err)
+	}
+
+	installName := "gauss"
+
+	values := values{
+		Promtail: promtail{
+			Config: promtailConfig{
+				Clients: []promtailConfigClient{
+					{
+						URL:      fmt.Sprintf("https://%s/loki/api/v1/push", lokiURL),
+						TenantID: "giantswarm",
+						BasicAuth: promtailConfigClientBasicAuth{
+							Username: writeUser,
+							Password: writePassword,
+						},
+						BackoffConfig: promtailConfigClientBackoffConfig{
+							MaxPeriod: "10m",
+						},
+						ExternalLabels: promtailConfigClientExternalLabels{
+							Installation: installName,
+							ClusterID:    lc.GetName(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	v, err := yaml.Marshal(values)
+	if err != nil {
+		return v1.Secret{}, errors.WithStack(err)
+	}
+
+	secret := v1.Secret{
+		ObjectMeta: SecretMeta(lc),
+		Data: map[string][]byte{
+			"values": []byte(v),
+		},
+	}
+
+	return secret, nil
+}
+
+// Read Loki URL from ingress
+func readLokiIngressURL(ctx context.Context, lc loggedcluster.Interface, client client.Client) (string, error) {
+
+	var lokiIngress netv1.Ingress
+
+	err := client.Get(ctx, types.NamespacedName{Name: lokiIngressName, Namespace: lokiIngressNamespace}, &lokiIngress)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	// We consider there's only one rule with one URL, because that's how the helm chart does it for the moment.
+	ingressURL := lokiIngress.Spec.Rules[0].Host
+
+	return ingressURL, nil
+}

--- a/pkg/resource/promtail-client/reconciler.go
+++ b/pkg/resource/promtail-client/reconciler.go
@@ -1,0 +1,94 @@
+package promtailclient
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Reconciler implements a reconciler.Interface to handle
+// Promtail client: extra promtail config about where and how to send logs
+type Reconciler struct {
+	client.Client
+}
+
+// ReconcileCreate ensures promtail secret is created with the right credentials
+func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("promtailclient create")
+
+	// Retrieve secret containing credentials
+	var loggingCredentialsSecret v1.Secret
+	err := r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
+		&loggingCredentialsSecret)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	// Retrieve Loki ingress name
+	lokiURL, err := readLokiIngressURL(ctx, lc, r.Client)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	// Get desired secret
+	desiredPromtailClientSecret, err := GeneratePromtailClientSecret(lc, &loggingCredentialsSecret, lokiURL)
+	if err != nil {
+		logger.Info("promtailclient - failed generating auth config!", "error", err)
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	// Check if secret already exists.
+	logger.Info("promtailclient - getting", "namespace", desiredPromtailClientSecret.GetNamespace(), "name", desiredPromtailClientSecret.GetName())
+	var currentPromtailClientSecret v1.Secret
+	err = r.Client.Get(ctx, types.NamespacedName{Name: desiredPromtailClientSecret.GetName(), Namespace: desiredPromtailClientSecret.GetNamespace()}, &currentPromtailClientSecret)
+	if err != nil {
+		if apimachineryerrors.IsNotFound(err) {
+			logger.Info("promtailclient not found, creating")
+			err = r.Client.Create(ctx, &desiredPromtailClientSecret)
+			if err != nil {
+				return ctrl.Result{}, errors.WithStack(err)
+			}
+		} else {
+			return ctrl.Result{}, errors.WithStack(err)
+		}
+	}
+
+	if !needUpdate(currentPromtailClientSecret, desiredPromtailClientSecret) {
+		logger.Info("promtailclient up to date")
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("promtailclient - updating")
+	err = r.Client.Update(ctx, &desiredPromtailClientSecret)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	logger.Info("promtailclient - done")
+	return ctrl.Result{}, nil
+}
+
+// ReconcileDelete - Not much to do here when a cluster is deleted
+func (r *Reconciler) ReconcileDelete(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("promtailclient delete")
+
+	return ctrl.Result{}, nil
+}
+
+// needUpdate return true if current.Data and desired.Data do not match.
+func needUpdate(current, desired v1.Secret) bool {
+	return !reflect.DeepEqual(current.Data, desired.Data)
+}

--- a/pkg/vintagemc/cluster.go
+++ b/pkg/vintagemc/cluster.go
@@ -20,6 +20,11 @@ func (o Object) AppConfigName(app string) string {
 	return app
 }
 
+func (o Object) GetClusterName() string {
+	// TODO - return installation name for vintage MC
+	return "gauss"
+}
+
 func (o Object) GetObject() client.Object {
 	return o.Object
 }

--- a/pkg/vintagemc/cluster.go
+++ b/pkg/vintagemc/cluster.go
@@ -1,8 +1,9 @@
 package vintagemc
 
 import (
-	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 )
 
 type Object struct {

--- a/pkg/vintagemc/cluster.go
+++ b/pkg/vintagemc/cluster.go
@@ -1,11 +1,13 @@
 package vintagemc
 
 import (
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Object struct {
 	client.Object
+	Options loggedcluster.Options
 }
 
 func (o Object) GetLoggingLabel() string {
@@ -21,8 +23,12 @@ func (o Object) AppConfigName(app string) string {
 }
 
 func (o Object) GetClusterName() string {
-	// TODO - return installation name for vintage MC
-	return "gauss"
+	// return installation name for vintage MC
+	return o.Options.InstallationName
+}
+
+func (o Object) GetInstallationName() string {
+	return o.Options.InstallationName
 }
 
 func (o Object) GetObject() client.Object {

--- a/pkg/vintagewc/cluster.go
+++ b/pkg/vintagewc/cluster.go
@@ -26,6 +26,10 @@ func (o Object) AppConfigName(app string) string {
 	return app
 }
 
+func (o Object) GetClusterName() string {
+	return o.Object.GetName()
+}
+
 func (o Object) GetObject() client.Object {
 	return o.Object
 }

--- a/pkg/vintagewc/cluster.go
+++ b/pkg/vintagewc/cluster.go
@@ -4,10 +4,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/logging-operator/pkg/key"
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 )
 
 type Object struct {
 	client.Object
+	Options loggedcluster.Options
 }
 
 func (o Object) GetLoggingLabel() string {
@@ -28,6 +30,10 @@ func (o Object) AppConfigName(app string) string {
 
 func (o Object) GetClusterName() string {
 	return o.Object.GetName()
+}
+
+func (o Object) GetInstallationName() string {
+	return o.Options.InstallationName
 }
 
 func (o Object) GetObject() client.Object {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27146

Add promtailclient reconciler

Currently missing cluster name detection for vintageMC, only works on `gauss`.