### PR TITLE
fix logging-operator promtail-wiring that deleted WC user configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.5] - 2023-09-20
+### Fixed
 
+- Ensure we do not delete observability-bundle user configs for workload clusters.
+
+## [0.0.5] - 2023-09-20
 
 ### Added
 

--- a/pkg/resource/logging-credentials/logging_operator_secrets.go
+++ b/pkg/resource/logging-credentials/logging_operator_secrets.go
@@ -75,7 +75,6 @@ func GetLogin(lc loggedcluster.Interface, credentialsSecret *v1.Secret, user str
 }
 
 func GetPass(lc loggedcluster.Interface, credentialsSecret *v1.Secret, user string) (string, error) {
-
 	pass, ok := credentialsSecret.Data[fmt.Sprintf("%spassword", user)]
 
 	if !ok {


### PR DESCRIPTION
Ensure we do not delete userconfigs for workload clusters to fix https://github.com/giantswarm/giantswarm/issues/28257