### PR TITLE
don't allow logging on WCs older than 19.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only workload clusters release >= v19.1.0 can enable logging.
+
 ## [0.0.7] - 2023-10-03
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.5
 	github.com/pkg/errors v0.9.1
+	golang.org/x/mod v0.9.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -345,6 +345,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.9.0 h1:KENHtAZL2y3NLMYZeHY9DW8HW8V+kQyJsY/V9JlKvCs=
+golang.org/x/mod v0.9.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/vintagewc/cluster.go
+++ b/pkg/vintagewc/cluster.go
@@ -1,6 +1,9 @@
 package vintagewc
 
 import (
+	"fmt"
+
+	"golang.org/x/mod/semver"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/logging-operator/pkg/key"
@@ -14,6 +17,14 @@ type Object struct {
 
 func (o Object) GetLoggingLabel() string {
 	labels := o.Object.GetLabels()
+
+	// Promtail only works starting with AWS version 19.1.0
+	clusterRelease := labels["release.giantswarm.io/version"]
+	// semver versions must be "vMAJOR[.MINOR[.PATCH[-PRERELEASE][+BUILD]]]"
+	clusterReleaseSemver := fmt.Sprintf("v%s", clusterRelease)
+	if semver.Compare(clusterReleaseSemver, "v19.1.0") == -1 {
+		return "false"
+	}
 
 	value := labels[key.LoggingLabel]
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2834

Only enable logging on WCs >= 19.1.0

The reason is promtail-app does not work on previous cluster versions.
