### PR TITLE
Add audit logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Audit logs in promtail config.
+
 ## [0.0.6] - 2023-09-28
 
 ### Fixed

--- a/pkg/resource/promtail-config/promtail-config.go
+++ b/pkg/resource/promtail-config/promtail-config.go
@@ -106,7 +106,6 @@ func GeneratePromtailConfig(lc loggedcluster.Interface) (v1.ConfigMap, error) {
 		Promtail: promtail{
 			ExtraArgs: []string{
 				"-log-config-reverse-order",
-				"-client.external-labels=nodename=$(NODENAME)",
 				"-config.expand-env=true",
 			},
 			ExtraEnv: []promtailExtraEnv{
@@ -149,6 +148,7 @@ func GeneratePromtailConfig(lc loggedcluster.Interface) (v1.ConfigMap, error) {
     labels:
       kind: audit-logs
       __path__: /var/log/apiserver/*.log
+      nodename: ${NODENAME:-unknown}
 `,
 					ExtraRelabelConfigs: extraRelabelConfigs,
 				},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28346

This PR adds lines in the promtail config so that it can retrieve audit logs. Currently testing on a v19.1.0 cluster