### PR TITLE
Have per-cluster credentials and orgid.

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,12 +1,10 @@
-# pkg:golang/golang.org/x/net@v0.8.0
-CVE-2023-3978 until=2023-10-13
-
 # pkg:golang/google.golang.org/grpc@v1.52.0
-CVE-2023-32731 until=2023-10-13
+CVE-2023-32731 until=2024-01-02
 
 # pkg:golang/k8s.io/apiserver@v0.26.1
-CVE-2020-8561 until=2023-10-13
+CVE-2020-8561 until=2024-01-02
 
 # pkg:golang/golang.org/x/net@v0.8.0
-CVE-2023-3978 until=2023-10-13
+CVE-2023-3978 until=2024-01-02
+CVE-2023-39325 until=2024-01-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Only workload clusters release >= v19.1.0 can enable logging.
+- each cluster has a dedicated user
+- each cluster sends data as a different tenant
 
 ## [0.0.7] - 2023-10-03
 

--- a/pkg/resource/logging-credentials/logging_operator_secrets.go
+++ b/pkg/resource/logging-credentials/logging_operator_secrets.go
@@ -126,14 +126,16 @@ func RemoveLoggingCredentials(lc loggedcluster.Interface, loggingCredentials *v1
 
 	// Check credentials for [clustername]
 	clusterName := lc.GetClusterName()
+	credsUsername := fmt.Sprintf("%suser", clusterName)
+	credsPassword := fmt.Sprintf("%spassword", clusterName)
 
-	if _, ok := loggingCredentials.Data[fmt.Sprintf("%suser", clusterName)]; ok {
-		delete(loggingCredentials.Data, fmt.Sprintf("%suser", clusterName))
+	if _, ok := loggingCredentials.Data[credsUsername]; ok {
+		delete(loggingCredentials.Data, credsUsername)
 		secretUpdated = true
 	}
 
-	if _, ok := loggingCredentials.Data[fmt.Sprintf("%spassword", clusterName)]; ok {
-		delete(loggingCredentials.Data, fmt.Sprintf("%spassword", clusterName))
+	if _, ok := loggingCredentials.Data[credsPassword]; ok {
+		delete(loggingCredentials.Data, credsPassword)
 		secretUpdated = true
 	}
 	return secretUpdated

--- a/pkg/resource/loki-auth/loki-auth.go
+++ b/pkg/resource/loki-auth/loki-auth.go
@@ -2,6 +2,8 @@ package lokiauth
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -46,10 +48,60 @@ func LokiAuthSecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 	return metadata
 }
 
+// listWriteUsers returns a map of users found in a credentialsSecret
+func listWriteUsers(credentialsSecret *v1.Secret) []string {
+	var usersList []string
+	for myUser := range credentialsSecret.Data {
+
+		userTrimmed := strings.TrimSuffix(myUser, "user")
+		// bypass entries that are not a user
+		if userTrimmed == myUser {
+			continue
+		}
+		// bypass read user
+		if userTrimmed == "read" {
+			continue
+		}
+
+		usersList = append(usersList, userTrimmed)
+	}
+
+	return usersList
+}
+
 // GenerateLokiAuthSecret returns a secret for
 // the Loki-multi-tenant-proxy auth config
 func GenerateLokiAuthSecret(lc loggedcluster.Interface, credentialsSecret *v1.Secret) (v1.Secret, error) {
 
+	// Init empty users structure
+	values := Values{
+		Users: []user{},
+	}
+	// Prepare read user's orgid with default values
+	// make sure to have at least 2 tenants for read user, to prevent writing with this user
+	readOrgid := "giantswarm|default"
+
+	// Loop on write users
+	for _, writeUser := range listWriteUsers(credentialsSecret) {
+
+		writePassword, err := loggingcredentials.GetPass(lc, credentialsSecret, writeUser)
+		if err != nil {
+			return v1.Secret{}, errors.WithStack(err)
+		}
+
+		values.Users = append(values.Users, user{
+			Username: writeUser,
+			Password: writePassword,
+			// we set the tenant even though it may be given by the sender (promtail)
+			// depending of loki-multi-teant-proxy config
+			Orgid: writeUser,
+		})
+
+		// Add write user to allowed tenants for read user
+		readOrgid = fmt.Sprintf("%s|%s", readOrgid, writeUser)
+	}
+
+	// Create read user
 	readUser, err := loggingcredentials.GetLogin(lc, credentialsSecret, "read")
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
@@ -59,33 +111,11 @@ func GenerateLokiAuthSecret(lc loggedcluster.Interface, credentialsSecret *v1.Se
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
 	}
-
-	writeUser, err := loggingcredentials.GetLogin(lc, credentialsSecret, "write")
-	if err != nil {
-		return v1.Secret{}, errors.WithStack(err)
-	}
-
-	writePassword, err := loggingcredentials.GetPass(lc, credentialsSecret, "write")
-	if err != nil {
-		return v1.Secret{}, errors.WithStack(err)
-	}
-
-	values := Values{
-		Users: []user{
-			{
-				Username: readUser,
-				Password: readPassword,
-				// make sure to have at least 2 tenants to prevent writing with this user
-				Orgid: "giantswarm|default",
-			},
-			{
-				Username: writeUser,
-				Password: writePassword,
-				// on the write path the tenant will be given by the sender (promtail)
-				Orgid: "none",
-			},
-		},
-	}
+	values.Users = append(values.Users, user{
+		Username: readUser,
+		Password: readPassword,
+		Orgid:    readOrgid,
+	})
 
 	v, err := yaml.Marshal(values)
 	if err != nil {

--- a/pkg/resource/promtail-client/promtail-client.go
+++ b/pkg/resource/promtail-client/promtail-client.go
@@ -74,12 +74,14 @@ func SecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 // the Loki-multi-tenant-proxy auth config
 func GeneratePromtailClientSecret(lc loggedcluster.Interface, credentialsSecret *v1.Secret, lokiURL string) (v1.Secret, error) {
 
-	writeUser, err := loggingcredentials.GetLogin(lc, credentialsSecret, "write")
+	clusterName := lc.GetClusterName()
+
+	writeUser, err := loggingcredentials.GetLogin(lc, credentialsSecret, clusterName)
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
 	}
 
-	writePassword, err := loggingcredentials.GetPass(lc, credentialsSecret, "write")
+	writePassword, err := loggingcredentials.GetPass(lc, credentialsSecret, clusterName)
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
 	}
@@ -92,7 +94,7 @@ func GeneratePromtailClientSecret(lc loggedcluster.Interface, credentialsSecret 
 				Clients: []promtailConfigClient{
 					{
 						URL:      fmt.Sprintf("https://%s/loki/api/v1/push", lokiURL),
-						TenantID: "giantswarm",
+						TenantID: clusterName,
 						BasicAuth: promtailConfigClientBasicAuth{
 							Username: writeUser,
 							Password: writePassword,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28445

Having per-cluster orgid will help with performance analysis and provide per-cluster rate limiting.
On top of per-cluster orgid, this patch also sets per-cluster user. So we can enforce the org according to the user.


And a dashboard to show the difference:
![image](https://github.com/giantswarm/logging-operator/assets/12008875/a1bffc3d-481d-4b15-ab54-54a9c69c1d05)
* yellow: `giantswarm` tenant for all logs
* green: `gauss` tenant
* blue: my test WC's tenant