### PR TITLE
change logging-credentials secret format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only workload clusters release >= v19.1.0 can enable logging.
 - each cluster has a dedicated user
 - each cluster sends data as a different tenant
+- update logging-credentials secret format
 
 ## [0.0.7] - 2023-10-03
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/gomega v1.27.5
 	github.com/pkg/errors v0.9.1
 	golang.org/x/mod v0.9.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1
 	k8s.io/client-go v0.26.1
@@ -66,7 +67,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/component-base v0.26.1 // indirect

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -4,6 +4,9 @@ import (
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 )
 
+// ReadUser is the global user for reading logs
+const ReadUser = "read"
+
 func IsLoggingEnabled(lc loggedcluster.Interface) bool {
 
 	// Logging should be enabled when all conditions are met:

--- a/pkg/resource/grafana-datasource/grafana-loki-datasource.go
+++ b/pkg/resource/grafana-datasource/grafana-loki-datasource.go
@@ -65,7 +65,7 @@ func GenerateDatasourceSecret(lc loggedcluster.Interface, credentialsSecret *v1.
 
 	user := common.ReadUser
 
-	password, err := loggingcredentials.GetPass(lc, credentialsSecret, user)
+	password, err := loggingcredentials.GetPassword(lc, credentialsSecret, user)
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
 	}

--- a/pkg/resource/grafana-datasource/grafana-loki-datasource.go
+++ b/pkg/resource/grafana-datasource/grafana-loki-datasource.go
@@ -63,12 +63,9 @@ func DatasourceSecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 // the Loki datasource for Grafana
 func GenerateDatasourceSecret(lc loggedcluster.Interface, credentialsSecret *v1.Secret) (v1.Secret, error) {
 
-	user, err := loggingcredentials.GetLogin(lc, credentialsSecret, "read")
-	if err != nil {
-		return v1.Secret{}, errors.WithStack(err)
-	}
+	user := common.ReadUser
 
-	password, err := loggingcredentials.GetPass(lc, credentialsSecret, "read")
+	password, err := loggingcredentials.GetPass(lc, credentialsSecret, user)
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
 	}

--- a/pkg/resource/logging-credentials/logging_operator_secrets.go
+++ b/pkg/resource/logging-credentials/logging_operator_secrets.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,6 +21,10 @@ const (
 	LoggingCredentialsName      = "logging-credentials"
 	LoggingCredentialsNamespace = "monitoring"
 )
+
+type user struct {
+	Password string `yaml:"password" json:"password"`
+}
 
 // LoggingCredentialsSecretMeta returns metadata for the logging-operator credentials secret.
 func LoggingCredentialsSecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
@@ -64,60 +69,71 @@ func GenerateLoggingCredentialsBasicSecret(lc loggedcluster.Interface) *v1.Secre
 	return &secret
 }
 
-func GetLogin(lc loggedcluster.Interface, credentialsSecret *v1.Secret, user string) (string, error) {
+func GetPass(lc loggedcluster.Interface, credentialsSecret *v1.Secret, username string) (string, error) {
+	var userYaml user
 
-	login, ok := credentialsSecret.Data[fmt.Sprintf("%suser", user)]
-
+	userSecret, ok := credentialsSecret.Data[username]
 	if !ok {
 		return "", errors.New("Not found")
 	}
-	return string(login), nil
-}
 
-func GetPass(lc loggedcluster.Interface, credentialsSecret *v1.Secret, user string) (string, error) {
-	pass, ok := credentialsSecret.Data[fmt.Sprintf("%spassword", user)]
-
-	if !ok {
-		return "", errors.New("Not found")
+	err := yaml.Unmarshal(userSecret, &userYaml)
+	if err != nil {
+		return "", errors.New(fmt.Sprintf("Invalid user %s", username))
 	}
-	return string(pass), nil
+
+	password := userYaml.Password
+
+	return string(password), nil
 }
 
 // AddLoggingCredentials - Add credentials to LoggingCredentials secret if needed
-func AddLoggingCredentials(lc loggedcluster.Interface, loggingCredentials *v1.Secret) bool {
+func AddLoggingCredentials(lc loggedcluster.Interface, loggingCredentials *v1.Secret) (bool, error) {
 
 	var secretUpdated bool = false
 
 	// Always check credentials for "readuser"
-	if _, ok := loggingCredentials.Data["readuser"]; !ok {
-		loggingCredentials.Data["readuser"] = []byte("read")
-		secretUpdated = true
-	}
-	if _, ok := loggingCredentials.Data["readpassword"]; !ok {
+	if _, ok := loggingCredentials.Data[common.ReadUser]; !ok {
+		readUser := user{}
+
 		password, err := genPassword()
 		if err != nil {
-			return false
+			return false, errors.New("Failed generating read password")
 		}
-		loggingCredentials.Data["readpassword"] = []byte(password)
+
+		readUser.Password = password
+
+		v, err := yaml.Marshal(readUser)
+		if err != nil {
+			return false, errors.New("Failed creating read user")
+		}
+
+		loggingCredentials.Data[common.ReadUser] = []byte(v)
 		secretUpdated = true
 	}
 
 	// Check credentials for [clustername]
 	clusterName := lc.GetClusterName()
-	if _, ok := loggingCredentials.Data[fmt.Sprintf("%suser", clusterName)]; !ok {
-		loggingCredentials.Data[fmt.Sprintf("%suser", clusterName)] = []byte(clusterName)
-		secretUpdated = true
-	}
-	if _, ok := loggingCredentials.Data[fmt.Sprintf("%spassword", clusterName)]; !ok {
+	if _, ok := loggingCredentials.Data[clusterName]; !ok {
+		clusterUser := user{}
+
 		password, err := genPassword()
 		if err != nil {
-			return false
+			return false, errors.New("Failed generating write password")
 		}
-		loggingCredentials.Data[fmt.Sprintf("%spassword", clusterName)] = []byte(password)
+
+		clusterUser.Password = password
+
+		v, err := yaml.Marshal(clusterUser)
+		if err != nil {
+			return false, errors.New("Failed creating write user")
+		}
+
+		loggingCredentials.Data[clusterName] = []byte(v)
 		secretUpdated = true
 	}
 
-	return secretUpdated
+	return secretUpdated, nil
 }
 
 // RemoveLoggingCredentials - Remove credentials from LoggingCredentials secret
@@ -126,17 +142,11 @@ func RemoveLoggingCredentials(lc loggedcluster.Interface, loggingCredentials *v1
 
 	// Check credentials for [clustername]
 	clusterName := lc.GetClusterName()
-	credsUsername := fmt.Sprintf("%suser", clusterName)
-	credsPassword := fmt.Sprintf("%spassword", clusterName)
 
-	if _, ok := loggingCredentials.Data[credsUsername]; ok {
-		delete(loggingCredentials.Data, credsUsername)
+	if _, ok := loggingCredentials.Data[clusterName]; ok {
+		delete(loggingCredentials.Data, clusterName)
 		secretUpdated = true
 	}
 
-	if _, ok := loggingCredentials.Data[credsPassword]; ok {
-		delete(loggingCredentials.Data, credsPassword)
-		secretUpdated = true
-	}
 	return secretUpdated
 }

--- a/pkg/resource/logging-credentials/logging_operator_secrets.go
+++ b/pkg/resource/logging-credentials/logging_operator_secrets.go
@@ -22,7 +22,7 @@ const (
 	LoggingCredentialsNamespace = "monitoring"
 )
 
-type user struct {
+type userCredentials struct {
 	Password string `yaml:"password" json:"password"`
 }
 
@@ -69,8 +69,8 @@ func GenerateLoggingCredentialsBasicSecret(lc loggedcluster.Interface) *v1.Secre
 	return &secret
 }
 
-func GetPass(lc loggedcluster.Interface, credentialsSecret *v1.Secret, username string) (string, error) {
-	var userYaml user
+func GetPassword(lc loggedcluster.Interface, credentialsSecret *v1.Secret, username string) (string, error) {
+	var userYaml userCredentials
 
 	userSecret, ok := credentialsSecret.Data[username]
 	if !ok {
@@ -94,7 +94,7 @@ func AddLoggingCredentials(lc loggedcluster.Interface, loggingCredentials *v1.Se
 
 	// Always check credentials for "readuser"
 	if _, ok := loggingCredentials.Data[common.ReadUser]; !ok {
-		readUser := user{}
+		readUser := userCredentials{}
 
 		password, err := genPassword()
 		if err != nil {
@@ -115,7 +115,7 @@ func AddLoggingCredentials(lc loggedcluster.Interface, loggingCredentials *v1.Se
 	// Check credentials for [clustername]
 	clusterName := lc.GetClusterName()
 	if _, ok := loggingCredentials.Data[clusterName]; !ok {
-		clusterUser := user{}
+		clusterUser := userCredentials{}
 
 		password, err := genPassword()
 		if err != nil {

--- a/pkg/resource/logging-credentials/reconciler.go
+++ b/pkg/resource/logging-credentials/reconciler.go
@@ -41,7 +41,10 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	}
 
 	// update the secret's contents if needed
-	secretUpdated := AddLoggingCredentials(lc, loggingCredentialsSecret)
+	secretUpdated, err := AddLoggingCredentials(lc, loggingCredentialsSecret)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
 
 	// Check if metadata has been updated
 	if !reflect.DeepEqual(loggingCredentialsSecret.ObjectMeta.Labels, LoggingCredentialsSecretMeta(lc).Labels) {

--- a/pkg/resource/loki-auth/loki-auth.go
+++ b/pkg/resource/loki-auth/loki-auth.go
@@ -79,7 +79,7 @@ func GenerateLokiAuthSecret(lc loggedcluster.Interface, credentialsSecret *v1.Se
 	// Loop on write users
 	for _, writeUser := range listWriteUsers(credentialsSecret) {
 
-		writePassword, err := loggingcredentials.GetPass(lc, credentialsSecret, writeUser)
+		writePassword, err := loggingcredentials.GetPassword(lc, credentialsSecret, writeUser)
 		if err != nil {
 			return v1.Secret{}, errors.WithStack(err)
 		}
@@ -99,7 +99,7 @@ func GenerateLokiAuthSecret(lc loggedcluster.Interface, credentialsSecret *v1.Se
 	// Create read user
 	readUser := common.ReadUser
 
-	readPassword, err := loggingcredentials.GetPass(lc, credentialsSecret, readUser)
+	readPassword, err := loggingcredentials.GetPassword(lc, credentialsSecret, readUser)
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
 	}

--- a/pkg/resource/loki-auth/loki-auth.go
+++ b/pkg/resource/loki-auth/loki-auth.go
@@ -54,11 +54,11 @@ func LokiAuthSecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 func listWriteUsers(credentialsSecret *v1.Secret) []string {
 	var usersList []string
 	for myUser := range credentialsSecret.Data {
+		// bypass read user
+		// bypass old creds (xxxuser and xxxpassword)
 
-		userTrimmed := strings.TrimSuffix(myUser, "user")
-		// bypass read user and entries that are not a user
-		if userTrimmed != myUser && userTrimmed != "read" {
-			usersList = append(usersList, userTrimmed)
+		if !strings.HasSuffix(myUser, "user") && !strings.HasSuffix(myUser, "password") && myUser != common.ReadUser {
+			usersList = append(usersList, myUser)
 		}
 	}
 
@@ -97,12 +97,9 @@ func GenerateLokiAuthSecret(lc loggedcluster.Interface, credentialsSecret *v1.Se
 	}
 
 	// Create read user
-	readUser, err := loggingcredentials.GetLogin(lc, credentialsSecret, "read")
-	if err != nil {
-		return v1.Secret{}, errors.WithStack(err)
-	}
+	readUser := common.ReadUser
 
-	readPassword, err := loggingcredentials.GetPass(lc, credentialsSecret, "read")
+	readPassword, err := loggingcredentials.GetPass(lc, credentialsSecret, readUser)
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
 	}

--- a/pkg/resource/promtail-client/promtail-client.go
+++ b/pkg/resource/promtail-client/promtail-client.go
@@ -76,10 +76,7 @@ func GeneratePromtailClientSecret(lc loggedcluster.Interface, credentialsSecret 
 
 	clusterName := lc.GetClusterName()
 
-	writeUser, err := loggingcredentials.GetLogin(lc, credentialsSecret, clusterName)
-	if err != nil {
-		return v1.Secret{}, errors.WithStack(err)
-	}
+	writeUser := clusterName
 
 	writePassword, err := loggingcredentials.GetPass(lc, credentialsSecret, clusterName)
 	if err != nil {

--- a/pkg/resource/promtail-client/promtail-client.go
+++ b/pkg/resource/promtail-client/promtail-client.go
@@ -78,7 +78,7 @@ func GeneratePromtailClientSecret(lc loggedcluster.Interface, credentialsSecret 
 
 	writeUser := clusterName
 
-	writePassword, err := loggingcredentials.GetPass(lc, credentialsSecret, clusterName)
+	writePassword, err := loggingcredentials.GetPassword(lc, credentialsSecret, clusterName)
 	if err != nil {
 		return v1.Secret{}, errors.WithStack(err)
 	}


### PR DESCRIPTION
Before:
```
data:
  gausspassword: [base64 pass]
  gaussuser: Z2F1c3M=
  readpassword: [base64 pass]
  readuser: cmVhZA==
  sm2t7password: [base64 pass]
  sm2t7user: c20ydDc=
```

After:
```
data:
  gauss: [base64 pass structure]
  read: [base64 pass structure]
  sm2t7: [base64 pass structure]
```

The base64 pass structure is simple (but can be expanded in the future if needed):
```
password: [password]
```