### PR TITLE
Default logging behavior on WCs reverted to disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- default logging behavior on WCs reverted to disable.
+
 ## [0.2.0] - 2023-11-09
 
 ### Added

--- a/pkg/logged-cluster/interface.go
+++ b/pkg/logged-cluster/interface.go
@@ -5,7 +5,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const LoggingEnabledDefault = true
+// LoggingEnabledDefault defines if WCs logs are collected by default
+const LoggingEnabledDefault = false
 
 // Interface contains the definition of functions that can differ between each type of cluster
 type Interface interface {


### PR DESCRIPTION
Related to [#inc-2023-11-10-lokiringunealthy-pvc-space-too-low](https://gigantic.slack.com/archives/C064ZHJ25BQ)

Enabling logging by default on all WCs generate too much traffic and loki-write disks get filled up.
We need to tune it better before enabling logging on all WCs.