### PR TITLE
Add kubernetes audit log labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add labels to kubernetes audit logs to reduce rate limiting and help discovering logs.
+
 ## [0.2.2] - 2023-11-14
 
 ### Fixed

--- a/pkg/resource/promtail-config/promtail-config.go
+++ b/pkg/resource/promtail-config/promtail-config.go
@@ -156,22 +156,14 @@ func GeneratePromtailConfig(lc loggedcluster.Interface) (v1.ConfigMap, error) {
   - json:
       expressions:
         objectRef: objectRef
-        level:     level
-        stage:     stage
-        verb:      verb
   - json:
       expressions:
         resource: resource
         namespace: namespace
-        name: name
       source: objectRef
   - labels:
-      level:
-      stage:
-      verb:
       resource:
       namespace:
-      name:
 `,
 					ExtraRelabelConfigs: extraRelabelConfigs,
 					AddScrapeJobLabel:   true,

--- a/pkg/resource/promtail-config/promtail-config.go
+++ b/pkg/resource/promtail-config/promtail-config.go
@@ -16,8 +16,7 @@ const (
 	promtailConfigName = "logging-config"
 )
 
-///// Promtail values config structure
-
+// /// Promtail values config structure
 type values struct {
 	Promtail promtail `yaml:"promtail" json:"promtail"`
 }
@@ -89,7 +88,6 @@ func ConfigMeta(lc loggedcluster.Interface) metav1.ObjectMeta {
 // GeneratePromtailConfig returns a configmap for
 // the promtail extra-config
 func GeneratePromtailConfig(lc loggedcluster.Interface) (v1.ConfigMap, error) {
-
 	// Scrape logs from kube-system and giantswarm namespaces only for WC clusters
 	var extraRelabelConfigs []extraRelabelConfig
 	if common.IsWorkloadCluster(lc) {
@@ -154,6 +152,26 @@ func GeneratePromtailConfig(lc loggedcluster.Interface) (v1.ConfigMap, error) {
       scrape_job: audit-logs
       __path__: /var/log/apiserver/*.log
       node_name: ${NODENAME:-unknown}
+  pipeline_stages:
+  - json:
+      expressions:
+        objectRef: objectRef
+        level:     level
+        stage:     stage
+        verb:      verb
+  - json:
+      expressions:
+        resource: resource
+        namespace: namespace
+        name: name
+      source: objectRef
+  - labels:
+      level:
+      stage:
+      verb:
+      resource:
+      namespace:
+      name:
 `,
 					ExtraRelabelConfigs: extraRelabelConfigs,
 					AddScrapeJobLabel:   true,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28841

This PR adds the following labels to the kubernetes audit logs:

- resource: Type of resource concenred by the audit log
- namespace: Namespace of the resource being touched