### PR TITLE
push to CAPZ and CAPVCD collections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,3 +62,31 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: capz-app-collection
+          app_name: "logging-operator"
+          app_namespace: "monitoring"
+          app_collection_repo: "capz-app-collection"
+          requires:
+            - push-logging-operator-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: "architect"
+          name: cloud-director-app-collection
+          app_name: "logging-operator"
+          app_namespace: "monitoring"
+          app_collection_repo: "cloud-director-app-collection"
+          requires:
+            - push-logging-operator-to-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - enable logging on WCs by default.
+- push to CAPZ and CAPVCD collections
 
 ## [0.3.0] - 2023-11-21
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2944 and https://github.com/giantswarm/roadmap/issues/2942

Push logging-operator to CAPZ and CAPA collections so we can setup logging on these installs.