### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.3.1] - 2023-12-04
 
 ### Changed

--- a/helm/logging-operator/values.yaml
+++ b/helm/logging-operator/values.yaml
@@ -7,7 +7,7 @@ image:
   tag: ""
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
   pullSecret:
     dockerConfigJSON: "Cg=="
 


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
