### PR TITLE
Ensure promtail config is reset everytime the observability bundle resource version is updated

### DIFF
--- a/internal/controller/capicluster_controller.go
+++ b/internal/controller/capicluster_controller.go
@@ -19,15 +19,19 @@ package controller
 import (
 	"context"
 
+	appv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/pkg/errors"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/giantswarm/logging-operator/internal/controller/predicates"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	"github.com/giantswarm/logging-operator/pkg/logged-cluster/capicluster"
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
@@ -81,5 +85,11 @@ func (r *CapiClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *CapiClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&capi.Cluster{}).
+		// This ensures we run the reconcile loop when the observability-bundle app resource version changes.
+		Watches(
+			&appv1alpha1.App{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicates.ObservabilityBundleAppVersionChangedPredicate{}),
+		).
 		Complete(r)
 }

--- a/internal/controller/capicluster_controller.go
+++ b/internal/controller/capicluster_controller.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/giantswarm/logging-operator/internal/controller/predicates"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
@@ -88,7 +89,14 @@ func (r *CapiClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// This ensures we run the reconcile loop when the observability-bundle app resource version changes.
 		Watches(
 			&appv1alpha1.App{},
-			&handler.EnqueueRequestForObject{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
+				return []reconcile.Request{
+					{NamespacedName: types.NamespacedName{
+						Name:      object.GetLabels()["giantswarm.io/cluster"],
+						Namespace: object.GetNamespace(),
+					}},
+				}
+			}),
 			builder.WithPredicates(predicates.ObservabilityBundleAppVersionChangedPredicate{}),
 		).
 		Complete(r)

--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -1,0 +1,29 @@
+package predicates
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ResourceVersionChangedPredicate implements a default update predicate function on resource version change.
+type ObservabilityBundleAppVersionChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements default UpdateEvent filter for validating resource version change.
+func (ObservabilityBundleAppVersionChangedPredicate) Update(e event.UpdateEvent) bool {
+	if e.ObjectOld == nil {
+		return false
+	}
+	if e.ObjectNew == nil {
+		return false
+	}
+
+	if len(e.ObjectOld.GetLabels()) == 0 || len(e.ObjectNew.GetLabels()) == 0 ||
+		e.ObjectOld.GetLabels()["app.kubernetes.io/name"] != "observability-bundle" ||
+		e.ObjectNew.GetLabels()["app.kubernetes.io/name"] != "observability-bundle" {
+		return false
+	}
+
+	return e.ObjectNew.GetResourceVersion() != e.ObjectOld.GetResourceVersion()
+}

--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -1,7 +1,6 @@
 package predicates
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/blang/semver"
@@ -27,6 +26,7 @@ func (ObservabilityBundleAppVersionChangedPredicate) Update(e event.UpdateEvent)
 	if !strings.Contains(e.ObjectOld.GetName(), "observability-bundle") || !strings.Contains(e.ObjectNew.GetName(), "observability-bundle") {
 		return false
 	}
+
 	var oldApp, newApp *appv1alpha1.App
 	var ok bool
 	if oldApp, ok = e.ObjectOld.(*appv1alpha1.App); !ok {
@@ -45,9 +45,5 @@ func (ObservabilityBundleAppVersionChangedPredicate) Update(e event.UpdateEvent)
 		return false
 	}
 	breakingVersion := semver.MustParse("1.0.0")
-
-	fmt.Printf("%v\n", oldApp)
-	fmt.Printf("%v\n", newApp)
-	fmt.Printf("%v\n", oldAppVersion.LT(breakingVersion) && newAppVersion.GTE(breakingVersion))
 	return oldAppVersion.LT(breakingVersion) && newAppVersion.GTE(breakingVersion)
 }

--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -40,7 +40,7 @@ func (ObservabilityBundleAppVersionChangedPredicate) Update(e event.UpdateEvent)
 	if err != nil {
 		return false
 	}
-	newAppVersion, err := semver.Parse(newApp.Spec.Version)
+	newAppVersion, err := semver.New(newApp.Spec.Version)
 	if err != nil {
 		return false
 	}

--- a/internal/controller/vintagemc_controller.go
+++ b/internal/controller/vintagemc_controller.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	appv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -106,8 +105,8 @@ func (r *VintageMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 				return []reconcile.Request{
 					{NamespacedName: types.NamespacedName{
-						Name:      object.GetLabels()["giantswarm.io/cluster"],
-						Namespace: fmt.Sprintf("org-%s", object.GetLabels()["giantswarm.io/organization"]),
+						Name:      "kubernetes",
+						Namespace: "default",
 					}},
 				}
 			}),

--- a/internal/controller/vintagewc_controller.go
+++ b/internal/controller/vintagewc_controller.go
@@ -19,15 +19,19 @@ package controller
 import (
 	"context"
 
+	appv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/pkg/errors"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	capiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/giantswarm/logging-operator/internal/controller/predicates"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	"github.com/giantswarm/logging-operator/pkg/logged-cluster/vintagewc"
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
@@ -81,5 +85,11 @@ func (r *VintageWCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 func (r *VintageWCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&capiv1beta1.Cluster{}).
+		// This ensures we run the reconcile loop when the observability-bundle app resource version changes.
+		Watches(
+			&appv1alpha1.App{},
+			&handler.EnqueueRequestForObject{},
+			builder.WithPredicates(predicates.ObservabilityBundleAppVersionChangedPredicate{}),
+		).
 		Complete(r)
 }

--- a/internal/controller/vintagewc_controller.go
+++ b/internal/controller/vintagewc_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	appv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -92,8 +93,8 @@ func (r *VintageWCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
 				return []reconcile.Request{
 					{NamespacedName: types.NamespacedName{
-						Name:      "kubernetes",
-						Namespace: "default",
+						Name:      object.GetLabels()["giantswarm.io/cluster"],
+						Namespace: fmt.Sprintf("org-%s", object.GetLabels()["giantswarm.io/organization"]),
 					}},
 				}
 			}),


### PR DESCRIPTION
Towards https://github.com/giantswarm/default-apps-aws/pull/378


This PR use controller runtime watches to be able to rerun a reconciliation loop if the observability-bundle app upgrades from a release prior to 1.0.0 to a release greater than 1.0.0 to fix a race condition issues related to the breaking changes in the bundle.