### PR TITLE
Fix logging-credentials delete reconciler on disabled MCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore not found error for clusters that have logging disabled.
+
 ## [0.4.2] - 2024-01-11
 
 ### Fixed

--- a/pkg/resource/logging-credentials/logging_operator_secrets.go
+++ b/pkg/resource/logging-credentials/logging_operator_secrets.go
@@ -60,7 +60,6 @@ func genPassword() (string, error) {
 // GenerateObservabilityBundleConfigMap returns a configmap for
 // the observabilitybundle application to enable promtail.
 func GenerateLoggingCredentialsBasicSecret(lc loggedcluster.Interface) *v1.Secret {
-
 	secret := v1.Secret{
 		ObjectMeta: LoggingCredentialsSecretMeta(lc),
 		Data:       map[string][]byte{},

--- a/pkg/resource/logging-credentials/reconciler.go
+++ b/pkg/resource/logging-credentials/reconciler.go
@@ -83,7 +83,12 @@ func (r *Reconciler) ReconcileDelete(ctx context.Context, lc loggedcluster.Inter
 	// Retrieve existing secret
 	err := r.Client.Get(ctx, types.NamespacedName{Name: LoggingCredentialsSecretMeta(lc).Name, Namespace: LoggingCredentialsSecretMeta(lc).Namespace}, loggingCredentialsSecret)
 	if err != nil {
-		return ctrl.Result{}, errors.WithStack(err)
+		if apimachineryerrors.IsNotFound(err) {
+			logger.Info("loggingcredentials secret not found, initializing one")
+			return ctrl.Result{}, nil
+		} else {
+			return ctrl.Result{}, errors.WithStack(err)
+		}
 	}
 
 	// update the secret's contents if needed


### PR DESCRIPTION
Closing https://github.com/giantswarm/giantswarm/issues/29521

This PR does not fail to reconcile if the loki secret is not found hence avoiding a useless error