### PR TITLE
Remove multi-tenant proxy restart hack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove multi-tenant proxy restart hack.
+
 ## [0.4.4] - 2024-01-22
 
 ### Changed

--- a/pkg/resource/loki-auth/reconciler.go
+++ b/pkg/resource/loki-auth/reconciler.go
@@ -70,13 +70,6 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	logger.Info("lokiauth - trigger loki-multi-tenant-auth-proxy restart")
-
-	err = ReloadLokiProxy(lc, ctx, r.Client)
-	if err != nil {
-		return ctrl.Result{}, errors.WithStack(err)
-	}
-
 	logger.Info("lokiauth - done")
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29580

This removes the hack we implemented to restart the multi-tenant proxy in favor of a config watcher/reloader in the app itself