### PR TITLE
Cache values in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Caches following values within the context to avoid fetching them multiple times:
+  - Observability bundle app version
+  - Grafana agent app
+  - Loki ingress URL
+  - Logging credentials
+
 ## [0.7.0] - 2024-07-19
 
 ### Added

--- a/pkg/resource/grafana-agent-config/reconciler.go
+++ b/pkg/resource/grafana-agent-config/reconciler.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/blang/semver"
-	appv1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,11 +46,8 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, nil
 	}
 
-	// Get observability bundle app metadata.
-	appMeta := common.ObservabilityBundleAppMeta(lc)
 	// Retrieve the app.
-	var currentApp appv1.App
-	err = r.Client.Get(ctx, types.NamespacedName{Name: lc.AppConfigName("grafana-agent"), Namespace: appMeta.GetNamespace()}, &currentApp)
+	currentApp, err := common.ReadGrafanaAgentApp(ctx, lc, r.Client)
 	if err != nil {
 		if apimachineryerrors.IsNotFound(err) {
 			logger.Info("grafana-agent-config - app not found, requeuing")

--- a/pkg/resource/grafana-datasource/reconciler.go
+++ b/pkg/resource/grafana-datasource/reconciler.go
@@ -29,9 +29,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	logger.Info("grafanadatasource create")
 
 	// Retrieve secret containing credentials
-	var loggingCredentialsSecret v1.Secret
-	err := r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
-		&loggingCredentialsSecret)
+	loggingCredentialsSecret, err := loggingcredentials.Read(ctx, lc, r.Client)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/logging-secret/reconciler.go
+++ b/pkg/resource/logging-secret/reconciler.go
@@ -30,9 +30,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	logger.Info("logging-secret create")
 
 	// Retrieve secret containing credentials
-	var loggingCredentialsSecret v1.Secret
-	err := r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
-		&loggingCredentialsSecret)
+	loggingCredentialsSecret, err := loggingcredentials.Read(ctx, lc, r.Client)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/loki-auth/reconciler.go
+++ b/pkg/resource/loki-auth/reconciler.go
@@ -29,9 +29,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	logger.Info("lokiauth create")
 
 	// Retrieve secret containing credentials
-	var lokiAuthSecret v1.Secret
-	err := r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
-		&lokiAuthSecret)
+	lokiAuthSecret, err := loggingcredentials.Read(ctx, lc, r.Client)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}


### PR DESCRIPTION
This PR propose a performance improvement by caching some values being used by multiple resources in the request context. It avoid those resources to be fetch from API mutliple times.
The caching is done the lazy way; within the function fetching those resources.

I would like someone with a broader overview of the operator and interaction between resources to confirm this does not break the current behaviour.
AFAIU the concerned resources are not modified within the request lifetime.