### PR TITLE
Reduce boilerplate code realted to resource creation and update

### DIFF
--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -12,6 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// Generic constaint to handle pointer type.
+// This constaint allow to use a pointer to T as generic type.
+// This contraint inherits from client.Object as we expect
+// pointer to T to satisfy the client.Object interface.
 type Ptr[T any] interface {
 	client.Object
 	*T

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -56,7 +56,7 @@ func EnsureCreatedOrUpdated[T any, PT Ptr[T]](ctx context.Context, client client
 	}
 
 	// Update the resource.
-	logger.Info(fmt.Sprintf("%s -updating", reconcilerName), "namespace", desiredResourcePtr.GetNamespace(), "name", desiredResourcePtr.GetName())
+	logger.Info(fmt.Sprintf("%s - updating", reconcilerName), "namespace", desiredResourcePtr.GetNamespace(), "name", desiredResourcePtr.GetName())
 	err = client.Update(ctx, desiredResourcePtr)
 	if err != nil {
 		return errors.WithStack(err)

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type Desired interface {
+	v1.ConfigMap | v1.Secret
+}
+
+type DesiredPtr[T any] interface {
+	client.Object
+	*T
+}
+
+func PointerTo[T any](v T) *T {
+	return &v
+}
+
+func Ensure[T Desired, PT DesiredPtr[T]](ctx context.Context, client client.Client, desiredResource T, needUpdate func(T, T) bool, reconcilerName string) error {
+	var (
+		currentResource    T
+		currentResourcePtr = PT(&currentResource)
+		desiredResourcePtr = PT(&desiredResource)
+	)
+	logger := log.FromContext(ctx)
+
+	// Check if config already exists.
+	logger.Info(fmt.Sprintf("%s - getting", reconcilerName), "namespace", desiredResourcePtr.GetNamespace(), "name", desiredResourcePtr.GetName())
+	err := client.Get(ctx, types.NamespacedName{Name: desiredResourcePtr.GetName(), Namespace: desiredResourcePtr.GetNamespace()}, currentResourcePtr)
+	if err != nil {
+		if apimachineryerrors.IsNotFound(err) {
+			logger.Info(fmt.Sprintf("%s - creating", reconcilerName), "namespace", desiredResourcePtr.GetNamespace(), "name", desiredResourcePtr.GetName())
+			err = client.Create(ctx, desiredResourcePtr)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			return nil
+		}
+		return errors.WithStack(err)
+	}
+
+	if !needUpdate(currentResource, desiredResource) {
+		logger.Info(fmt.Sprintf("%s - up to date", reconcilerName), "namespace", desiredResourcePtr.GetNamespace(), "name", desiredResourcePtr.GetName())
+		return nil
+	}
+
+	logger.Info(fmt.Sprintf("%s -updating", reconcilerName), "namespace", desiredResourcePtr.GetNamespace(), "name", desiredResourcePtr.GetName())
+	err = client.Update(ctx, desiredResourcePtr)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}

--- a/pkg/common/resource.go
+++ b/pkg/common/resource.go
@@ -17,10 +17,10 @@ type Ptr[T any] interface {
 	*T
 }
 
-// Ensure ensure the desiredResource exists and is up to date in the Kubernetes API.
+// EnsureCreatedOrUpdated ensure the desiredResource exists and is up to date in the Kubernetes API.
 // If the resource does not exist, it will be created.
 // If the resource exists but is not up to date, it will be updated when needUpdate returns true.
-func Ensure[T any, PT Ptr[T]](ctx context.Context, client client.Client, desiredResource T, needUpdate func(T, T) bool, reconcilerName string) error {
+func EnsureCreatedOrUpdated[T any, PT Ptr[T]](ctx context.Context, client client.Client, desiredResource T, needUpdate func(T, T) bool, reconcilerName string) error {
 	var (
 		currentResource    T
 		currentResourcePtr = PT(&currentResource)

--- a/pkg/resource/grafana-agent-config/reconciler.go
+++ b/pkg/resource/grafana-agent-config/reconciler.go
@@ -68,7 +68,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	err = common.Ensure(ctx, r.Client, desiredGrafanaAgentConfig, needUpdate, "grafana-agent-config")
+	err = common.EnsureCreatedOrUpdated(ctx, r.Client, desiredGrafanaAgentConfig, needUpdate, "grafana-agent-config")
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/grafana-agent-secret/reconciler.go
+++ b/pkg/resource/grafana-agent-secret/reconciler.go
@@ -82,7 +82,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	err = common.Ensure(ctx, r.Client, desiredGrafanaAgentSecret, needUpdate, "grafana-agent-secret")
+	err = common.EnsureCreatedOrUpdated(ctx, r.Client, desiredGrafanaAgentSecret, needUpdate, "grafana-agent-secret")
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/grafana-datasource/reconciler.go
+++ b/pkg/resource/grafana-datasource/reconciler.go
@@ -43,7 +43,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	err = common.Ensure(ctx, r.Client, desiredDatasourceSecret, needUpdate, "grafanadatasource")
+	err = common.EnsureCreatedOrUpdated(ctx, r.Client, desiredDatasourceSecret, needUpdate, "grafanadatasource")
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/logging-agents-toggle/reconciler.go
+++ b/pkg/resource/logging-agents-toggle/reconciler.go
@@ -50,7 +50,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	err = common.Ensure(ctx, r.Client, desiredConfigMap, needUpdate, "logging-agent-toggle")
+	err = common.EnsureCreatedOrUpdated(ctx, r.Client, desiredConfigMap, needUpdate, "logging-agent-toggle")
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/logging-config/reconciler.go
+++ b/pkg/resource/logging-config/reconciler.go
@@ -35,7 +35,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	err = common.Ensure(ctx, r.Client, desiredLoggingConfig, needUpdate, "logging-config")
+	err = common.EnsureCreatedOrUpdated(ctx, r.Client, desiredLoggingConfig, needUpdate, "logging-config")
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/logging-secret/reconciler.go
+++ b/pkg/resource/logging-secret/reconciler.go
@@ -50,7 +50,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	err = common.Ensure(ctx, r.Client, desiredLoggingSecret, needUpdate, "logging-secret")
+	err = common.EnsureCreatedOrUpdated(ctx, r.Client, desiredLoggingSecret, needUpdate, "logging-secret")
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/loki-auth/reconciler.go
+++ b/pkg/resource/loki-auth/reconciler.go
@@ -43,7 +43,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	err = common.Ensure(ctx, r.Client, desiredLokiAuthSecret, needUpdate, "lokiauth")
+	err = common.EnsureCreatedOrUpdated(ctx, r.Client, desiredLokiAuthSecret, needUpdate, "lokiauth")
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}


### PR DESCRIPTION
This PR provides a solution to reduce the amount of duplicated code to create and update resources in the Kubernetes API.

It does so by using a generic function `common.EnsureCreatedOrUpdated` (suggestion welcome for naming).

This function encapsulates the logic to check if the resource exists and to create or update it. It can work with any object that satisfies the `client.Object` interface and takes the famous `needUpdate` function to decide whether the resource should be updated or not.

This was mainly motivated by a) reducing boilerplate and b) playing with generics in a real world scenario.