### PR TITLE
Add PreFetchers to reduce code duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add PreFetcher to store following values within the context to avoid code duplication across resources:
+  - Observability bundle app version
+  - Grafana agent app
+  - Loki ingress URL
+  - Logging credentials
+
 ## [0.7.0] - 2024-07-19
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/giantswarm/logging-operator/internal/controller"
+	"github.com/giantswarm/logging-operator/pkg/common"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 	loggingreconciler "github.com/giantswarm/logging-operator/pkg/logging-reconciler"
 	"github.com/giantswarm/logging-operator/pkg/reconciler"
@@ -165,6 +166,12 @@ func main() {
 	loggingReconciler := loggingreconciler.LoggingReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		PreFetchers: []loggingreconciler.PreFetcher{
+			common.NewLokiIngressURLContext,
+			common.NewGrafanaAgentAppContext,
+			common.NewObservabilityBundleAppVersionContext,
+			loggingcredentials.NewContext,
+		},
 		Reconcilers: []reconciler.Interface{
 			&loggingAgentsToggle,
 			&loggingWiring,

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -2,11 +2,16 @@ package common
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 	netv1 "k8s.io/api/networking/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appv1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 )
@@ -45,17 +50,58 @@ func IsWorkloadCluster(lc loggedcluster.Interface) bool {
 	return lc.GetInstallationName() != lc.GetClusterName()
 }
 
-// Read Loki URL from ingress
-func ReadLokiIngressURL(ctx context.Context, lc loggedcluster.Interface, client client.Client) (string, error) {
+type lokiIngressURLContextKey int
+
+var lokiIngressURLKey lokiIngressURLContextKey
+
+// NewLokiIngressURLContext reads the Loki Ingress URL from the API and stores it in the context.
+func NewLokiIngressURLContext(ctx context.Context, lc loggedcluster.Interface, client client.Client) (context.Context, ctrl.Result, error) {
 	var lokiIngress netv1.Ingress
 
 	err := client.Get(ctx, types.NamespacedName{Name: lokiIngressName, Namespace: lokiIngressNamespace}, &lokiIngress)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return nil, ctrl.Result{}, errors.WithStack(err)
 	}
 
 	// We consider there's only one rule with one URL, because that's how the helm chart does it for the moment.
 	ingressURL := lokiIngress.Spec.Rules[0].Host
 
-	return ingressURL, nil
+	ctx = context.WithValue(ctx, lokiIngressURLKey, ingressURL)
+
+	return ctx, ctrl.Result{}, nil
+}
+
+func LokiIngressURLFromContext(ctx context.Context) (string, bool) {
+	lokiIngressURL, ok := ctx.Value(lokiIngressURLKey).(string)
+	return lokiIngressURL, ok
+}
+
+type grafanaAgentAppContextKey int
+
+var grafanaAgentAppKey grafanaAgentAppContextKey
+
+// NewGrafanaAgentAppContext retrieves the grafana-agent app from the API and stores it in the context.
+func NewGrafanaAgentAppContext(ctx context.Context, lc loggedcluster.Interface, client client.Client) (context.Context, ctrl.Result, error) {
+	var currentApp appv1.App
+
+	appMeta := ObservabilityBundleAppMeta(lc)
+
+	// Check existence of grafana-agent app
+	err := client.Get(ctx, types.NamespacedName{Name: lc.AppConfigName("grafana-agent"), Namespace: appMeta.GetNamespace()}, &currentApp)
+	if err != nil {
+		if apimachineryerrors.IsNotFound(err) {
+			// If the app is not found we should requeue and try again later (5 minutes is the app platform default reconciliation time)
+			return nil, ctrl.Result{RequeueAfter: time.Duration(5 * time.Minute)}, nil
+		}
+		return nil, ctrl.Result{}, errors.WithStack(err)
+	}
+
+	ctx = context.WithValue(ctx, grafanaAgentAppKey, currentApp)
+
+	return ctx, ctrl.Result{}, nil
+}
+
+func GrafanaAgentAppFromContext(ctx context.Context) (appv1.App, bool) {
+	grafanaAgentApp, ok := ctx.Value(grafanaAgentAppKey).(appv1.App)
+	return grafanaAgentApp, ok
 }

--- a/pkg/logging-reconciler/pre-fetch.go
+++ b/pkg/logging-reconciler/pre-fetch.go
@@ -1,0 +1,12 @@
+package loggingreconciler
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+)
+
+type PreFetcher func(context.Context, loggedcluster.Interface, client.Client) (context.Context, ctrl.Result, error)

--- a/pkg/resource/grafana-agent-secret/reconciler.go
+++ b/pkg/resource/grafana-agent-secret/reconciler.go
@@ -3,10 +3,8 @@ package grafanaagentsecret
 import (
 	"context"
 	"reflect"
-	"time"
 
 	"github.com/blang/semver"
-	appv1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -32,14 +30,9 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	logger := log.FromContext(ctx)
 	logger.Info("grafana-agent-secret create")
 
-	observabilityBundleVersion, err := common.GetObservabilityBundleAppVersion(lc, r.Client, ctx)
-	if err != nil {
-		// Handle case where the app is not found.
-		if apimachineryerrors.IsNotFound(err) {
-			logger.Info("grafana-agent-secret - observability bundle app not found, requeueing")
-			// If the app is not found we should requeue and try again later (5 minutes is the app platform default reconciliation time)
-			return ctrl.Result{RequeueAfter: time.Duration(5 * time.Minute)}, nil
-		}
+	observabilityBundleVersion, ok := common.ObservabilityBundleAppVersionFromContext(ctx)
+	if !ok {
+		err := errors.New("grafana-agent-secret - observability bundle app version not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
@@ -49,29 +42,23 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	}
 
 	// Check existence of grafana-agent app
-	var currentApp appv1.App
-	appMeta := common.ObservabilityBundleAppMeta(lc)
-	err = r.Client.Get(ctx, types.NamespacedName{Name: lc.AppConfigName("grafana-agent"), Namespace: appMeta.GetNamespace()}, &currentApp)
-	if err != nil {
-		if apimachineryerrors.IsNotFound(err) {
-			logger.Info("grafana-agent-secret - app not found, requeuing")
-			// If the app is not found we should requeue and try again later (5 minutes is the app platform default reconciliation time)
-			return ctrl.Result{RequeueAfter: time.Duration(5 * time.Minute)}, nil
-		}
+	_, ok = common.GrafanaAgentAppFromContext(ctx)
+	if !ok {
+		err := errors.New("grafana-agent-secret - grafana agent app not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
 	// Retrieve secret containing credentials
-	var loggingCredentialsSecret v1.Secret
-	err = r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
-		&loggingCredentialsSecret)
-	if err != nil {
+	loggingCredentialsSecret, ok := loggingcredentials.FromContext(ctx)
+	if !ok {
+		err := errors.New("grafana-agents-secret - logging credentials secret not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	// Retrieve Loki ingress name
-	lokiURL, err := common.ReadLokiIngressURL(ctx, lc, r.Client)
-	if err != nil {
+	// Retrieve Loki ingress url
+	lokiURL, ok := common.LokiIngressURLFromContext(ctx)
+	if !ok {
+		err := errors.New("grafana-agent-secret - loki ingress URL not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 

--- a/pkg/resource/grafana-datasource/reconciler.go
+++ b/pkg/resource/grafana-datasource/reconciler.go
@@ -29,10 +29,9 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	logger.Info("grafanadatasource create")
 
 	// Retrieve secret containing credentials
-	var loggingCredentialsSecret v1.Secret
-	err := r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
-		&loggingCredentialsSecret)
-	if err != nil {
+	loggingCredentialsSecret, ok := loggingcredentials.FromContext(ctx)
+	if !ok {
+		err := errors.New("grafanadatasource - logging credentials secret not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 

--- a/pkg/resource/logging-agents-toggle/reconciler.go
+++ b/pkg/resource/logging-agents-toggle/reconciler.go
@@ -3,10 +3,7 @@ package loggingagentstoggle
 import (
 	"context"
 	"reflect"
-	"time"
 
-	"github.com/blang/semver"
-	appv1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,14 +30,9 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	logger := log.FromContext(ctx)
 	logger.Info("Logging agents toggle create")
 
-	observabilityBundleVersion, err := common.GetObservabilityBundleAppVersion(lc, r.Client, ctx)
-	if err != nil {
-		// Handle case where the app is not found.
-		if apimachineryerrors.IsNotFound(err) {
-			logger.Info("logging-agents-toggle - observability bundle app not found, requeueing")
-			// If the app is not found we should requeue and try again later (5 minutes is the app platform default reconciliation time)
-			return ctrl.Result{RequeueAfter: time.Duration(5 * time.Minute)}, nil
-		}
+	observabilityBundleVersion, ok := common.ObservabilityBundleAppVersionFromContext(ctx)
+	if !ok {
+		err := errors.New("logging-agent-toggle - observability bundle app version not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
@@ -85,23 +77,9 @@ func (r *Reconciler) ReconcileDelete(ctx context.Context, lc loggedcluster.Inter
 	logger := log.FromContext(ctx)
 	logger.Info("Logging agents toggle delete")
 
-	// Get observability bundle app metadata.
-	appMeta := common.ObservabilityBundleAppMeta(lc)
-	// Retrieve the app.
-	var currentApp appv1.App
-	err := r.Client.Get(ctx, types.NamespacedName{Name: appMeta.GetName(), Namespace: appMeta.GetNamespace()}, &currentApp)
-	if err != nil {
-		// Handle case where the app is not found.
-		if apimachineryerrors.IsNotFound(err) {
-			logger.Info("logging-agents-toggle - observability bundle app not found, skipping deletion")
-			// If the app is not found we ignore the error and return, as this means the app was already deleted.
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, errors.WithStack(err)
-	}
-
-	observabilityBundleVersion, err := semver.Parse(currentApp.Spec.Version)
-	if err != nil {
+	observabilityBundleVersion, ok := common.ObservabilityBundleAppVersionFromContext(ctx)
+	if !ok {
+		err := errors.New("logging-agent-toggle - observability bundle app version not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 

--- a/pkg/resource/logging-credentials/context.go
+++ b/pkg/resource/logging-credentials/context.go
@@ -1,0 +1,36 @@
+package loggingcredentials
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+)
+
+type loggingCredentialsContextKey int
+
+var loggingCredentialsSecretKey loggingCredentialsContextKey
+
+func NewContext(ctx context.Context, lc loggedcluster.Interface, client client.Client) (context.Context, ctrl.Result, error) {
+	var loggingCredentialsSecret v1.Secret
+
+	err := client.Get(ctx, types.NamespacedName{Name: LoggingCredentialsSecretMeta(lc).Name, Namespace: LoggingCredentialsSecretMeta(lc).Namespace},
+		&loggingCredentialsSecret)
+	if err != nil {
+		return nil, ctrl.Result{}, err
+	}
+
+	ctx = context.WithValue(ctx, loggingCredentialsSecretKey, loggingCredentialsSecret)
+
+	return ctx, ctrl.Result{}, nil
+}
+
+func FromContext(ctx context.Context) (v1.Secret, bool) {
+	loggingCredentialsSecret, ok := ctx.Value(loggingCredentialsSecretKey).(v1.Secret)
+	return loggingCredentialsSecret, ok
+}

--- a/pkg/resource/logging-secret/reconciler.go
+++ b/pkg/resource/logging-secret/reconciler.go
@@ -30,16 +30,16 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	logger.Info("logging-secret create")
 
 	// Retrieve secret containing credentials
-	var loggingCredentialsSecret v1.Secret
-	err := r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
-		&loggingCredentialsSecret)
-	if err != nil {
+	loggingCredentialsSecret, ok := loggingcredentials.FromContext(ctx)
+	if !ok {
+		err := errors.New("logging-secret - logging credentials secret not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
 	// Retrieve Loki ingress name
-	lokiURL, err := common.ReadLokiIngressURL(ctx, lc, r.Client)
-	if err != nil {
+	lokiURL, ok := common.LokiIngressURLFromContext(ctx)
+	if !ok {
+		err := errors.New("loki ingress URL not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 

--- a/pkg/resource/loki-auth/reconciler.go
+++ b/pkg/resource/loki-auth/reconciler.go
@@ -29,10 +29,9 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	logger.Info("lokiauth create")
 
 	// Retrieve secret containing credentials
-	var lokiAuthSecret v1.Secret
-	err := r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
-		&lokiAuthSecret)
-	if err != nil {
+	lokiAuthSecret, ok := loggingcredentials.FromContext(ctx)
+	if !ok {
+		err := errors.New("lokiauth - logging credentials secret not found in context")
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 


### PR DESCRIPTION
Here is my second attempt at reducing code duplication (after https://github.com/giantswarm/logging-operator/pull/168)

The main idea here is to store some values in context in order to make them available later for the reconcilers. This is achieved by registering some `PreFetcher` function which are executed prior to the reconcilers and update the context which is then passed to each reconciler. Reconciler can then retrieve those values from context directly.

Values added as PreFetcher:

- Add Observability bundle app version
- Add Loki ingress URL
- Add Grafana App
- Add Logging credentials

Note: I sticked with moving values in context as this allow for all the logic for error handling and so on, to move at an early stage and not be duplicated later on.