### PR TITLE
rename alloy-logs to alloyLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix incorrect Alloy secret and Alloy config templating.
+- Rename `alloy-logs` to came case `alloyLogs` in the observability-bundle config.
 
 ## [0.7.0] - 2024-07-19
 

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -25,8 +25,13 @@ const (
 	LoggingAgentPromtail = "promtail"
 	LoggingAgentAlloy    = "alloy"
 
+	// App name keys in the observability bundle
+	AlloyObservabilityBundleAppName          = "alloyLogs"
+	PromtailObservabilityBundleAppName       = "promtail"
+	PromtailObservabilityBundleLegacyAppName = "promtail-app"
+
 	// Alloy app name and namespace when using Alloy as logging agent.
-	AlloyLogAgentAppName      = "alloyLogs"
+	AlloyLogAgentAppName      = "alloy-logs"
 	AlloyLogAgentAppNamespace = "kube-system"
 
 	MaxBackoffPeriod = "10m"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -26,7 +26,7 @@ const (
 	LoggingAgentAlloy    = "alloy"
 
 	// Alloy app name and namespace when using Alloy as logging agent.
-	AlloyLogAgentAppName      = "alloy-logs"
+	AlloyLogAgentAppName      = "alloyLogs"
 	AlloyLogAgentAppNamespace = "kube-system"
 
 	MaxBackoffPeriod = "10m"

--- a/pkg/resource/alloy-secret/reconciler.go
+++ b/pkg/resource/alloy-secret/reconciler.go
@@ -47,7 +47,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	err := r.Client.Get(ctx, types.NamespacedName{Name: lc.AppConfigName(common.AlloyLogAgentAppName), Namespace: appMeta.GetNamespace()}, &currentApp)
 	if err != nil {
 		if apimachineryerrors.IsNotFound(err) {
-			logger.Info(fmt.Sprintf("alloy-secret - %s app not found, requeuing", common.AlloyLogAgentAppName))
+			logger.Info(fmt.Sprintf("alloy-secret - %s app not found, requeuing", lc.AppConfigName(common.AlloyLogAgentAppName)))
 			// If the app is not found we should requeue and try again later (5 minutes is the app platform default reconciliation time)
 			return ctrl.Result{RequeueAfter: time.Duration(5 * time.Minute)}, nil
 		}

--- a/pkg/resource/logging-agents-toggle/observability_bundle_configmap.go
+++ b/pkg/resource/logging-agents-toggle/observability_bundle_configmap.go
@@ -27,9 +27,9 @@ type app struct {
 func GenerateObservabilityBundleConfigMap(ctx context.Context, lc loggedcluster.Interface, observabilityBundleVersion semver.Version) (v1.ConfigMap, error) {
 	appsToEnable := map[string]app{}
 
-	promtailAppName := "promtail"
+	promtailAppName := common.PromtailObservabilityBundleAppName
 	if observabilityBundleVersion.LT(semver.MustParse("1.0.0")) {
-		promtailAppName = "promtail-app"
+		promtailAppName = common.PromtailObservabilityBundleLegacyAppName
 	}
 
 	// Enforce promtail as logging agent when observability-bundle version < 1.5.0
@@ -44,11 +44,11 @@ func GenerateObservabilityBundleConfigMap(ctx context.Context, lc loggedcluster.
 		appsToEnable[promtailAppName] = app{
 			Enabled: true,
 		}
-		appsToEnable[common.AlloyLogAgentAppName] = app{
+		appsToEnable[common.AlloyObservabilityBundleAppName] = app{
 			Enabled: false,
 		}
 	case common.LoggingAgentAlloy:
-		appsToEnable[common.AlloyLogAgentAppName] = app{
+		appsToEnable[common.AlloyObservabilityBundleAppName] = app{
 			Enabled:   true,
 			Namespace: common.AlloyLogAgentAppNamespace,
 		}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3524

The naming style of Alloy app in the observability bundle is wrong as we are using camel case values there.

```
$ k -n=org-giantswarm get cm golem-observability-bundle-logging-extraconfig -oyaml|bl -p
apiVersion: v1
data:
  values: |
    apps:
      alloy-logs:      <--- here
        enabled: false
      grafanaAgent:
        enabled: true
      promtail:
        enabled: true
kind: ConfigMap
metadata:
  name: golem-observability-bundle-logging-extraconfig
  namespace: org-giantswarm
```

This PR fixes this issue by renaming alloy-logs to alloyLogs in the observability-bundle config generated by the logging operator.