### PR TITLE
Fix required observability bundle version to run Alloy as logging agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix required observability bundle version to run Alloy as logging agent.
+
 ## [0.7.2] - 2024-08-12
 
 ### Fixed

--- a/pkg/resource/logging-agents-toggle/observability_bundle_configmap.go
+++ b/pkg/resource/logging-agents-toggle/observability_bundle_configmap.go
@@ -32,8 +32,8 @@ func GenerateObservabilityBundleConfigMap(ctx context.Context, lc loggedcluster.
 		promtailAppName = common.PromtailObservabilityBundleLegacyAppName
 	}
 
-	// Enforce promtail as logging agent when observability-bundle version < 1.5.0
-	if observabilityBundleVersion.LT(semver.MustParse("1.5.0")) && lc.GetLoggingAgent() == common.LoggingAgentAlloy {
+	// Enforce promtail as logging agent when observability-bundle version < 1.5.3
+	if observabilityBundleVersion.LT(semver.MustParse("1.5.3")) && lc.GetLoggingAgent() == common.LoggingAgentAlloy {
 		logger := log.FromContext(ctx)
 		logger.Info("Logging agent is not supported by observability bundle, using promtail instead.", "observability-bundle-version", observabilityBundleVersion, "logging-agent", lc.GetLoggingAgent())
 		lc.SetLoggingAgent(common.LoggingAgentPromtail)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3524

Since the renaming of Alloy app from alloy-logs to alloyLogs in v0.7.1 the logging-operator now required observability bundle version v1.5.3 to run Alloy as logging agent.