### PR TITLE
Fix Alloy logs secret handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Alloy logs secret handling
+
 ## [0.10.0] - 2024-09-10
 
 ### Changed

--- a/pkg/resource/alloy-secret/alloy-logging-secret.go
+++ b/pkg/resource/alloy-secret/alloy-logging-secret.go
@@ -3,49 +3,15 @@ package alloysecret
 import (
 	"fmt"
 
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/logging-operator/pkg/common"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
-	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 )
 
 const (
 	secretName = "alloy-logging-secret" // #nosec G101
-
-	AlloyLokiURLEnvVarName           = "LOKI_URL"
-	AlloyTenantIDEnvVarName          = "TENANT_ID"
-	AlloyBasicAuthUsernameEnvVarName = "BASIC_AUTH_USERNAME"
-	AlloyBasicAuthPasswordEnvVarName = "BASIC_AUTH_PASSWORD" // #nosec G101
 )
-
-func GenerateAlloyLoggingSecret(lc loggedcluster.Interface, credentialsSecret *v1.Secret, lokiURL string) (v1.Secret, error) {
-	clusterName := lc.GetClusterName()
-
-	writePassword, err := loggingcredentials.GetPassword(lc, credentialsSecret, clusterName)
-	if err != nil {
-		return v1.Secret{}, err
-	}
-
-	LokiURL := fmt.Sprintf(common.LokiURLFormat, lokiURL)
-	TenantID := clusterName
-	BasicAuthUsername := clusterName
-	BasicAuthPassword := writePassword
-
-	data := make(map[string][]byte)
-	data[AlloyLokiURLEnvVarName] = []byte(LokiURL)
-	data[AlloyTenantIDEnvVarName] = []byte(TenantID)
-	data[AlloyBasicAuthUsernameEnvVarName] = []byte(BasicAuthUsername)
-	data[AlloyBasicAuthPasswordEnvVarName] = []byte(BasicAuthPassword)
-
-	secret := v1.Secret{
-		ObjectMeta: SecretMeta(lc),
-		Data:       data,
-	}
-
-	return secret, nil
-}
 
 // SecretMeta returns metadata for the Alloy secret.
 func SecretMeta(lc loggedcluster.Interface) metav1.ObjectMeta {

--- a/pkg/resource/alloy-secret/reconciler.go
+++ b/pkg/resource/alloy-secret/reconciler.go
@@ -2,20 +2,15 @@ package alloysecret
 
 import (
 	"context"
-	"fmt"
 	"reflect"
-	"time"
 
-	appv1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/giantswarm/logging-operator/pkg/common"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
-	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,81 +24,12 @@ type Reconciler struct {
 
 // ReconcileCreate ensures Alloy secret is created with the right credentials
 func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Interface) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-	logger.Info("alloy-secret - create")
-
-	if lc.GetLoggingAgent() != common.LoggingAgentAlloy {
-		logger.Info(fmt.Sprintf("alloy-secret - logging agent is not %s, skipping", common.LoggingAgentAlloy))
-		result, err := r.ReconcileDelete(ctx, lc)
-		if err != nil {
-			return result, errors.WithStack(err)
-		}
-		return result, nil
-	}
-
-	// Check existence of Alloy app
-	var currentApp appv1.App
-	appMeta := common.ObservabilityBundleAppMeta(lc)
-	err := r.Client.Get(ctx, types.NamespacedName{Name: lc.AppConfigName(common.AlloyLogAgentAppName), Namespace: appMeta.GetNamespace()}, &currentApp)
-	if err != nil {
-		if apimachineryerrors.IsNotFound(err) {
-			logger.Info(fmt.Sprintf("alloy-secret - %s app not found, requeuing", lc.AppConfigName(common.AlloyLogAgentAppName)))
-			// If the app is not found we should requeue and try again later (5 minutes is the app platform default reconciliation time)
-			return ctrl.Result{RequeueAfter: time.Duration(5 * time.Minute)}, nil
-		}
-		return ctrl.Result{}, errors.WithStack(err)
-	}
-
-	// Retrieve secret containing credentials
-	var loggingCredentialsSecret v1.Secret
-	err = r.Client.Get(ctx, types.NamespacedName{Name: loggingcredentials.LoggingCredentialsSecretMeta(lc).Name, Namespace: loggingcredentials.LoggingCredentialsSecretMeta(lc).Namespace},
-		&loggingCredentialsSecret)
+	result, err := r.ReconcileDelete(ctx, lc)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
-	// Retrieve Loki ingress name
-	lokiURL, err := common.ReadProxyIngressURL(ctx, lc, r.Client)
-	if err != nil {
-		return ctrl.Result{}, errors.WithStack(err)
-	}
-
-	// Get desired secret
-	desiredAlloySecret, err := GenerateAlloyLoggingSecret(lc, &loggingCredentialsSecret, lokiURL)
-	if err != nil {
-		logger.Info("alloy-secret - failed generating alloy secret!", "error", err)
-		return ctrl.Result{}, errors.WithStack(err)
-	}
-
-	// Check if secret already exists.
-	logger.Info("alloy-secret - getting secret", "namespace", desiredAlloySecret.GetNamespace(), "name", desiredAlloySecret.GetName())
-	var currentAlloySecret v1.Secret
-	err = r.Client.Get(ctx, types.NamespacedName{Name: desiredAlloySecret.GetName(), Namespace: desiredAlloySecret.GetNamespace()}, &currentAlloySecret)
-	if err != nil {
-		if apimachineryerrors.IsNotFound(err) {
-			logger.Info("alloy-secret - secret not found, creating")
-			err = r.Client.Create(ctx, &desiredAlloySecret)
-			if err != nil {
-				return ctrl.Result{}, errors.WithStack(err)
-			}
-		} else {
-			return ctrl.Result{}, errors.WithStack(err)
-		}
-	}
-
-	if !needUpdate(currentAlloySecret, desiredAlloySecret) {
-		logger.Info("alloy-secret - secret up to date")
-		return ctrl.Result{}, nil
-	}
-
-	logger.Info("alloy-secret - updating secret", "namespace", desiredAlloySecret.GetNamespace(), "name", desiredAlloySecret.GetName())
-	err = r.Client.Update(ctx, &desiredAlloySecret)
-	if err != nil {
-		return ctrl.Result{}, errors.WithStack(err)
-	}
-
-	logger.Info("alloy-secret - secret updated")
-	return ctrl.Result{}, nil
+	return result, nil
 }
 
 // ReconcileDelete ensure Alloy secret is deleted for the given cluster.

--- a/pkg/resource/logging-config/alloy-logging-config.go
+++ b/pkg/resource/logging-config/alloy-logging-config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/giantswarm/logging-operator/pkg/common"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
-	alloysecret "github.com/giantswarm/logging-operator/pkg/resource/alloy-secret"
+	loggingsecret "github.com/giantswarm/logging-operator/pkg/resource/logging-secret"
 )
 
 var (
@@ -37,14 +37,12 @@ func GenerateAlloyLoggingConfig(lc loggedcluster.Interface) (string, error) {
 		return "", err
 	}
 
-	secretMeta := alloysecret.SecretMeta(lc)
-
 	data := struct {
 		AlloyConfig string
 		SecretName  string
 	}{
 		AlloyConfig: alloyConfig,
-		SecretName:  secretMeta.GetName(),
+		SecretName:  common.AlloyLogAgentAppName,
 	}
 
 	err = alloyLoggingConfigTemplate.Execute(&values, data)
@@ -74,10 +72,10 @@ func generateAlloyConfig(lc loggedcluster.Interface) (string, error) {
 		Installation:                lc.GetInstallationName(),
 		MaxBackoffPeriod:            common.MaxBackoffPeriod,
 		IsWorkloadCluster:           common.IsWorkloadCluster(lc),
-		LokiURLEnvVarName:           alloysecret.AlloyLokiURLEnvVarName,
-		TenantIDEnvVarName:          alloysecret.AlloyTenantIDEnvVarName,
-		BasicAuthUsernameEnvVarName: alloysecret.AlloyBasicAuthUsernameEnvVarName,
-		BasicAuthPasswordEnvVarName: alloysecret.AlloyBasicAuthPasswordEnvVarName,
+		LokiURLEnvVarName:           loggingsecret.AlloyLokiURLEnvVarName,
+		TenantIDEnvVarName:          loggingsecret.AlloyTenantIDEnvVarName,
+		BasicAuthUsernameEnvVarName: loggingsecret.AlloyBasicAuthUsernameEnvVarName,
+		BasicAuthPasswordEnvVarName: loggingsecret.AlloyBasicAuthPasswordEnvVarName,
 	}
 
 	err := alloyLoggingTemplate.Execute(&values, data)

--- a/pkg/resource/logging-secret/alloy-logging-secret.go
+++ b/pkg/resource/logging-secret/alloy-logging-secret.go
@@ -1,13 +1,69 @@
 package loggingsecret
 
 import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"text/template"
+
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/Masterminds/sprig/v3"
+
+	"github.com/giantswarm/logging-operator/pkg/common"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
+	loggingcredentials "github.com/giantswarm/logging-operator/pkg/resource/logging-credentials"
 )
 
+const (
+	AlloyLokiURLEnvVarName           = "LOKI_URL"
+	AlloyTenantIDEnvVarName          = "TENANT_ID"
+	AlloyBasicAuthUsernameEnvVarName = "BASIC_AUTH_USERNAME"
+	AlloyBasicAuthPasswordEnvVarName = "BASIC_AUTH_PASSWORD" // #nosec G101
+)
+
+var (
+	//go:embed alloy/logging-secret.yaml.template
+	alloySecret         string
+	alloySecretTemplate *template.Template
+)
+
+func init() {
+	alloySecretTemplate = template.Must(template.New("logging-secret.yaml").Funcs(sprig.FuncMap()).Parse(alloySecret))
+}
+
 func GenerateAlloyLoggingSecret(lc loggedcluster.Interface, credentialsSecret *v1.Secret, lokiURL string) (map[string][]byte, error) {
+	clusterName := lc.GetClusterName()
+
+	writePassword, err := loggingcredentials.GetPassword(lc, credentialsSecret, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	LokiURL := fmt.Sprintf(common.LokiURLFormat, lokiURL)
+	TenantID := clusterName
+	BasicAuthUsername := clusterName
+	BasicAuthPassword := writePassword
+
+	templateData := struct {
+		ExtraSecretEnv map[string]string
+	}{
+		ExtraSecretEnv: map[string]string{
+			AlloyLokiURLEnvVarName:           LokiURL,
+			AlloyTenantIDEnvVarName:          TenantID,
+			AlloyBasicAuthUsernameEnvVarName: BasicAuthUsername,
+			AlloyBasicAuthPasswordEnvVarName: BasicAuthPassword,
+		},
+	}
+
+	var values bytes.Buffer
+	err = alloySecretTemplate.Execute(&values, templateData)
+	if err != nil {
+		return nil, err
+	}
+
 	data := make(map[string][]byte)
+	data["values"] = values.Bytes()
 
 	return data, nil
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3524

Fixes an issue where the current secret is always created on the MC which makes it impossible to configure Alloy logs on a WC.

  - Pass secret environment variables via helm chart values
    using the extraSecretEnv directive
  - Ensure old secret is deleted