### PR TITLE
fix v0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix v0.11.0 release was not published
+
 ## [0.11.0] - 2024-09-18
 
 ### Fixed


### PR DESCRIPTION
Release v0.11.0 was merged with `theo.brigitte@gmail.com` commit message, which did not trigger the release creation. https://github.com/giantswarm/logging-operator/commit/57bfa4d17ba960beb4a17903473216b15058ab18