### PR TITLE
fix promtail usage of stuctured-metadata for v19 clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix usage of structured metadata for clusters before v20.
+
 ## [0.12.0] - 2024-09-23
 
 ### Changed

--- a/pkg/resource/logging-config/logging-config.go
+++ b/pkg/resource/logging-config/logging-config.go
@@ -6,6 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 
 	"github.com/giantswarm/logging-operator/pkg/common"
@@ -16,13 +17,13 @@ const (
 	loggingConfigName = "logging-config"
 )
 
-func GenerateLoggingConfig(lc loggedcluster.Interface) (v1.ConfigMap, error) {
+func GenerateLoggingConfig(lc loggedcluster.Interface, observabilityBundleVersion semver.Version) (v1.ConfigMap, error) {
 	var values string
 	var err error
 
 	switch lc.GetLoggingAgent() {
 	case common.LoggingAgentPromtail:
-		values, err = GeneratePromtailLoggingConfig(lc)
+		values, err = GeneratePromtailLoggingConfig(lc, observabilityBundleVersion)
 		if err != nil {
 			return v1.ConfigMap{}, err
 		}

--- a/pkg/resource/logging-config/promtail-logging-config.go
+++ b/pkg/resource/logging-config/promtail-logging-config.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/blang/semver"
 
 	"github.com/giantswarm/logging-operator/pkg/common"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
@@ -24,13 +25,16 @@ func init() {
 
 // GeneratePromtailLoggingConfig returns a configmap for
 // the logging extra-config
-func GeneratePromtailLoggingConfig(lc loggedcluster.Interface) (string, error) {
+func GeneratePromtailLoggingConfig(lc loggedcluster.Interface, observabilityBundleVersion semver.Version) (string, error) {
 	var values bytes.Buffer
 
 	data := struct {
-		IsWorkloadCluster bool
+		IsWorkloadCluster          bool
+		SupportsStructuredMetadata bool
 	}{
 		IsWorkloadCluster: common.IsWorkloadCluster(lc),
+		// Promtail in older versions do not support structured metadata.
+		SupportsStructuredMetadata: observabilityBundleVersion.GTE(semver.MustParse("1.0.0")),
 	}
 
 	err := promtailLoggingConfigTemplate.Execute(&values, data)

--- a/pkg/resource/logging-config/promtail/logging-config.promtail.yaml.template
+++ b/pkg/resource/logging-config/promtail/logging-config.promtail.yaml.template
@@ -95,6 +95,7 @@ promtail:
                 resource: resource
                 namespace: namespace
               source: objectRef
+          {{- if .SupportsStructuredMetadata }}
           - structured_metadata:
               resource:
               filename:
@@ -102,6 +103,12 @@ promtail:
               - filename
           - labels:
               namespace:
+          {{- else }}
+          - labels:
+              namespace:
+              filename:
+          {{- end }}
+      {{- if .SupportsStructuredMetadata }}
       pipelineStages:
         - cri: {}
         - structured_metadata:
@@ -110,6 +117,7 @@ promtail:
         - labeldrop:
             - filename
             - stream
+      {{- end }}
   extraArgs:
   - -log-config-reverse-order
   - -config.expand-env=true

--- a/pkg/resource/logging-config/reconciler.go
+++ b/pkg/resource/logging-config/reconciler.go
@@ -3,12 +3,14 @@ package loggingconfig
 import (
 	"context"
 	"reflect"
+	"time"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/giantswarm/logging-operator/pkg/common"
 	loggedcluster "github.com/giantswarm/logging-operator/pkg/logged-cluster"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -27,8 +29,19 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	logger := log.FromContext(ctx)
 	logger.Info("logging-config create")
 
+	observabilityBundleVersion, err := common.GetObservabilityBundleAppVersion(lc, r.Client, ctx)
+	if err != nil {
+		// Handle case where the app is not found.
+		if apimachineryerrors.IsNotFound(err) {
+			logger.Info("logging-config - observability bundle app not found, requeueing")
+			// If the app is not found we should requeue and try again later (5 minutes is the app platform default reconciliation time)
+			return ctrl.Result{RequeueAfter: time.Duration(5 * time.Minute)}, nil
+		}
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
 	// Get desired config
-	desiredLoggingConfig, err := GenerateLoggingConfig(lc)
+	desiredLoggingConfig, err := GenerateLoggingConfig(lc, observabilityBundleVersion)
 	if err != nil {
 		logger.Info("logging-config - failed generating logging config!", "error", err)
 		return ctrl.Result{}, errors.WithStack(err)


### PR DESCRIPTION
Structured metadata was added to promtail 2.9.0 which was added to v20 so we make sure structured_metadata is only used for those versions.