### PR TITLE
Change default logging agent to alloy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change default logging agent to Alloy instead of Promtail.
+
 ## [0.13.0] - 2024-10-24
 
 ### Added

--- a/helm/logging-operator/values.yaml
+++ b/helm/logging-operator/values.yaml
@@ -41,7 +41,7 @@ loggingOperator:
   defaultNamespaces: "kube-system,giantswarm"
   vintageMode: true
   loggingEnabled: true
-  loggingAgent: promtail
+  loggingAgent: alloy
 
 managementCluster:
   name: unknown

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableLogging, "enable-logging", true, "enable/disable logging for the whole installation")
-	flag.StringVar(&loggingAgent, "logging-agent", common.LoggingAgentPromtail, fmt.Sprintf("select logging agent to use (%s or %s)", common.LoggingAgentPromtail, common.LoggingAgentAlloy))
+	flag.StringVar(&loggingAgent, "logging-agent", common.LoggingAgentAlloy, fmt.Sprintf("select logging agent to use (%s or %s)", common.LoggingAgentPromtail, common.LoggingAgentAlloy))
 	flag.StringVar(&installationName, "installation-name", "unknown", "Name of the installation")
 	flag.BoolVar(&insecureCA, "insecure-ca", false, "Is the management cluter CA insecure?")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")


### PR DESCRIPTION
### What this PR does / why we need it

Towards: https://github.com/giantswarm/roadmap/issues/3525

Set the default monitoring agent to Alloy so all cluster from capa v29.1.0, capz v29.0.0 will use Alloy instead of Promtail.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
