### PR TITLE
force reconciliation whenever the observability-bundle version changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reconcile clusters for any observability bundle version change after v1.0.0 instead of only when we upgrade to v1.0.0 because app upgrades happen way after cluster changes when upgrading a cluster.
+
 ## [0.14.0] - 2024-10-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reconcile clusters for any observability bundle version change after v1.0.0 instead of only when we upgrade to v1.0.0 because app upgrades happen way after cluster changes when upgrading a cluster.
+- Reconcile clusters when the observability bundle version changes.
 
 ## [0.14.0] - 2024-10-29
 

--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -27,23 +27,16 @@ func (ObservabilityBundleAppVersionChangedPredicate) Update(e event.UpdateEvent)
 		return false
 	}
 
-	var oldApp, newApp *appv1alpha1.App
+	var newApp *appv1alpha1.App
 	var ok bool
-	if oldApp, ok = e.ObjectOld.(*appv1alpha1.App); !ok {
-		return false
-	}
 	if newApp, ok = e.ObjectNew.(*appv1alpha1.App); !ok {
 		return false
 	}
 
-	oldAppVersion, err := semver.New(oldApp.Spec.Version)
-	if err != nil {
-		return false
-	}
 	newAppVersion, err := semver.New(newApp.Spec.Version)
 	if err != nil {
 		return false
 	}
 	breakingVersion := semver.MustParse("1.0.0")
-	return oldAppVersion.LT(breakingVersion) && newAppVersion.GTE(breakingVersion)
+	return newAppVersion.GTE(breakingVersion)
 }

--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -36,11 +36,11 @@ func (ObservabilityBundleAppVersionChangedPredicate) Update(e event.UpdateEvent)
 		return false
 	}
 
-	oldAppVersion, err := semver.New(oldApp.Spec.Version)
+	oldAppVersion, err := semver.Parse(oldApp.Spec.Version)
 	if err != nil {
 		return false
 	}
-	newAppVersion, err := semver.New(newApp.Spec.Version)
+	newAppVersion, err := semver.Parse(newApp.Spec.Version)
 	if err != nil {
 		return false
 	}

--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -44,6 +44,5 @@ func (ObservabilityBundleAppVersionChangedPredicate) Update(e event.UpdateEvent)
 	if err != nil {
 		return false
 	}
-	breakingVersion := semver.MustParse("1.0.0")
-	return oldAppVersion.NE(newAppVersion) && newAppVersion.GTE(breakingVersion)
+	return oldAppVersion.NE(newAppVersion)
 }

--- a/tests/ats/Pipfile
+++ b/tests/ats/Pipfile
@@ -4,9 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-pytest-helm-charts = ">=1.0.2"
-pytest = ">=6.2.5"
-pykube-ng = ">=22.1.0"
+pytest-helm-charts = ">=1.3.2"
+pytest = ">=8.3.3"
+pykube-ng = ">=23.6.0"
 pytest-rerunfailures = "~=14.0"
 
 [requires]

--- a/tests/ats/Pipfile.lock
+++ b/tests/ats/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9aa59f02e9a6252096efe3e9f6e2f27d2962ecc8376b896428b3c539fdc52c88"
+            "sha256": "c4cc3fa6e5b5cb1818c550469f0103c4ed5bbc6d92e2dbe3d11bd9dd04b6ea5f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -195,12 +195,12 @@
         },
         "pytest-helm-charts": {
             "hashes": [
-                "sha256:0995723f4298eb1accf6a4e01df9cc4e2bf1f2a746ee2d4249d8f70e68ea04f7",
-                "sha256:8725e6f44661264e08acc7252762c31706e5791c8ff9a05dcf7889c3f96dc992"
+                "sha256:8bfc6e4f00a275abf67f7e602c8b6b551bad4a5c7d76bacb390512f9f0fa6e1a",
+                "sha256:f860b1ffdad3faafc8e14b44cb256bddbac11f0badc93bdb129fe66494e89bf3"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10' and python_version < '4.0'",
-            "version": "==1.3.1"
+            "version": "==1.3.2"
         },
         "pytest-rerunfailures": {
             "hashes": [


### PR DESCRIPTION
### What this PR does / why we need it

This PR fixes the current cluster upgrade issues that has been happening in releases since we enabled alloy as our default logging agent.


For context, here is how a cluster upgrade goes:

1. Upgrade Cluster CR
2. All operators act on it including the logging-operator which generates the config for the currently deployed observability version

The issue here is that in when we upgrade capv releases from v28 to v29, we upgrade the observability bundle from a version < 1.5.3 to a version >= 1.5.3 which is when we deploy alloy as our logging agent: https://github.com/giantswarm/logging-operator/blob/1e338f926451a65f456d00cc155366631ffc13d5/pkg/resource/logging-agents-toggle/observability_bundle_configmap.go#L36

As controllers run in parallel, this causes a race condition between the component that deploys the new app versions and the logging-operator which acts faster so the generated config targets an old observability-bundle version that does not use alloy and so does not create the secret alloy needs to start https://github.com/giantswarm/logging-operator/blob/1e338f926451a65f456d00cc155366631ffc13d5/pkg/resource/logging-secret/logging-secret.go#L30

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
