### PR TITLE
fix failing release upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixes the current version that enabled alloy-logs as the new secret mechanism only works with alloy 0.4.0 which is is the observability bundle 1.6.0
+
 ## [0.15.0] - 2024-10-31
 
 ### Changed

--- a/pkg/resource/logging-agents-toggle/observability_bundle_configmap.go
+++ b/pkg/resource/logging-agents-toggle/observability_bundle_configmap.go
@@ -32,8 +32,8 @@ func GenerateObservabilityBundleConfigMap(ctx context.Context, lc loggedcluster.
 		promtailAppName = common.PromtailObservabilityBundleLegacyAppName
 	}
 
-	// Enforce promtail as logging agent when observability-bundle version < 1.5.3
-	if observabilityBundleVersion.LT(semver.MustParse("1.5.3")) && lc.GetLoggingAgent() == common.LoggingAgentAlloy {
+	// Enforce promtail as logging agent when observability-bundle version < 1.6.0 because this needs alloy 0.4.0.
+	if observabilityBundleVersion.LT(semver.MustParse("1.6.0")) && lc.GetLoggingAgent() == common.LoggingAgentAlloy {
 		logger := log.FromContext(ctx)
 		logger.Info("Logging agent is not supported by observability bundle, using promtail instead.", "observability-bundle-version", observabilityBundleVersion, "logging-agent", lc.GetLoggingAgent())
 		lc.SetLoggingAgent(common.LoggingAgentPromtail)


### PR DESCRIPTION
### What this PR does / why we need it

Fixes issues when running observability bundle 1.5.3 as it does not support the [new secret configuration mechanism ](https://github.com/giantswarm/alloy-app/blob/main/CHANGELOG.md#040---2024-08-12)added in observability bundle [1.6.0](https://github.com/giantswarm/observability-bundle/blob/main/CHANGELOG.md#160---2024-08-20). This causes clusters with version 1.5.3 and alloy enabled to fail

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
