### PR TITLE
fix workload cluster pod logs selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix invalid workload cluster pod logs selectors.
+
 ## [0.20.0] - 2025-01-14
 
 ### Added

--- a/pkg/resource/logging-config/alloy/logging-config.alloy.yaml.template
+++ b/pkg/resource/logging-config/alloy/logging-config.alloy.yaml.template
@@ -74,10 +74,7 @@ podLogs:
 - name: default-namespaces
   namespace: kube-system
   spec:
-    selector:
-      matchExpressions:
-      - key: observability.giantswarm.io/tenant
-        operator: Exists
+    selector: {}
     namespaceSelector:
       matchExpressions:
       - key: kubernetes.io/metadata.name
@@ -93,7 +90,10 @@ podLogs:
 - name: customers-logs
   namespace: kube-system
   spec:
-    selector: {}
+    selector:
+      matchExpressions:
+      - key: observability.giantswarm.io/tenant
+        operator: Exists
     namespaceSelector:
       matchExpressions:
       - key: kubernetes.io/metadata.name

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
@@ -358,10 +358,7 @@ podLogs:
 - name: default-namespaces
   namespace: kube-system
   spec:
-    selector:
-      matchExpressions:
-      - key: observability.giantswarm.io/tenant
-        operator: Exists
+    selector: {}
     namespaceSelector:
       matchExpressions:
       - key: kubernetes.io/metadata.name
@@ -375,7 +372,10 @@ podLogs:
 - name: customers-logs
   namespace: kube-system
   spec:
-    selector: {}
+    selector:
+      matchExpressions:
+      - key: observability.giantswarm.io/tenant
+        operator: Exists
     namespaceSelector:
       matchExpressions:
       - key: kubernetes.io/metadata.name


### PR DESCRIPTION
### What this PR does / why we need it

This fixes the pod logs selectors as they customer WCs pod logs selectors were incorrectly exchanged

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
