### PR TITLE
Fix `job` label in logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the `job` label in logs, by removing the associated relabeling rule.
+
 ## [0.20.1] - 2025-01-30
 
 ### Fixed

--- a/pkg/resource/logging-config/alloy/logging.alloy.template
+++ b/pkg/resource/logging-config/alloy/logging.alloy.template
@@ -74,12 +74,6 @@ discovery.relabel "kubernetes_pods" {
 	}
 
 	rule {
-		source_labels = ["namespace", "app"]
-		separator     = "/"
-		target_label  = "job"
-	}
-
-	rule {
 		source_labels = ["__meta_kubernetes_pod_name"]
 		target_label  = "pod"
 	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
@@ -75,12 +75,6 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["namespace", "app"]
-        		separator     = "/"
-        		target_label  = "job"
-        	}
-        
-        	rule {
         		source_labels = ["__meta_kubernetes_pod_name"]
         		target_label  = "pod"
         	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
@@ -75,12 +75,6 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["namespace", "app"]
-        		separator     = "/"
-        		target_label  = "job"
-        	}
-        
-        	rule {
         		source_labels = ["__meta_kubernetes_pod_name"]
         		target_label  = "pod"
         	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
@@ -69,12 +69,6 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["namespace", "app"]
-        		separator     = "/"
-        		target_label  = "job"
-        	}
-        
-        	rule {
         		source_labels = ["__meta_kubernetes_pod_name"]
         		target_label  = "pod"
         	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
@@ -69,12 +69,6 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["namespace", "app"]
-        		separator     = "/"
-        		target_label  = "job"
-        	}
-        
-        	rule {
         		source_labels = ["__meta_kubernetes_pod_name"]
         		target_label  = "pod"
         	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
@@ -69,12 +69,6 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["namespace", "app"]
-        		separator     = "/"
-        		target_label  = "job"
-        	}
-        
-        	rule {
         		source_labels = ["__meta_kubernetes_pod_name"]
         		target_label  = "pod"
         	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
@@ -69,12 +69,6 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["namespace", "app"]
-        		separator     = "/"
-        		target_label  = "job"
-        	}
-        
-        	rule {
         		source_labels = ["__meta_kubernetes_pod_name"]
         		target_label  = "pod"
         	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3855

This PRs fixes the `job` label in the logs by removing the `job` relabeling rule which make the default job label appear in logs.

The job label will then be shown as `<pod log namespace/<pod log name>`.

![image](https://github.com/user-attachments/assets/2a54c9e8-762e-42ba-bb37-6eda3e71755d)
