### PR TITLE
Fix namespace, pod, and container log label

### DIFF
--- a/pkg/resource/logging-config/alloy/logging.alloy.template
+++ b/pkg/resource/logging-config/alloy/logging.alloy.template
@@ -68,6 +68,7 @@ discovery.relabel "kubernetes_pods" {
 		target_label  = "node"
 	}
 
+	{{- if .SupportPodLogs }}
 	rule {
 		source_labels = ["instance"]
 		regex         = "(.+)/.+"
@@ -85,6 +86,22 @@ discovery.relabel "kubernetes_pods" {
 		regex         = ".+/.+:(.+)"
 		target_label  = "container"
 	}
+	{{- else }}
+	rule {
+		source_labels = ["__meta_kubernetes_namespace"]
+		target_label  = "namespace"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_name"]
+		target_label  = "pod"
+	}
+
+	rule {
+		source_labels = ["__meta_kubernetes_pod_container_name"]
+		target_label  = "container"
+	}
+	{{- end }}
 
 	{{- if .SupportPodLogs }}
 	rule {

--- a/pkg/resource/logging-config/alloy/logging.alloy.template
+++ b/pkg/resource/logging-config/alloy/logging.alloy.template
@@ -69,17 +69,20 @@ discovery.relabel "kubernetes_pods" {
 	}
 
 	rule {
-		source_labels = ["__meta_kubernetes_namespace"]
+		source_labels = ["instance"]
+		regex         = "(.+)/.+"
 		target_label  = "namespace"
 	}
 
 	rule {
-		source_labels = ["__meta_kubernetes_pod_name"]
+		source_labels = ["instance"]
+		regex         = ".+/(.+):.+"
 		target_label  = "pod"
 	}
 
 	rule {
-		source_labels = ["__meta_kubernetes_pod_container_name"]
+		source_labels = ["instance"]
+		regex         = ".+/.+:(.+)"
 		target_label  = "container"
 	}
 

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
@@ -68,22 +68,18 @@ alloy:
         		source_labels = ["__meta_kubernetes_pod_node_name"]
         		target_label  = "node"
         	}
-        
         	rule {
-        		source_labels = ["instance"]
-        		regex         = "(.+)/.+"
+        		source_labels = ["__meta_kubernetes_namespace"]
         		target_label  = "namespace"
         	}
         
         	rule {
-        		source_labels = ["instance"]
-        		regex         = ".+/(.+):.+"
+        		source_labels = ["__meta_kubernetes_pod_name"]
         		target_label  = "pod"
         	}
         
         	rule {
-        		source_labels = ["instance"]
-        		regex         = ".+/.+:(.+)"
+        		source_labels = ["__meta_kubernetes_pod_container_name"]
         		target_label  = "container"
         	}
         	rule {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
@@ -70,17 +70,20 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_namespace"]
+        		source_labels = ["instance"]
+        		regex         = "(.+)/.+"
         		target_label  = "namespace"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/(.+):.+"
         		target_label  = "pod"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_container_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/.+:(.+)"
         		target_label  = "container"
         	}
         	rule {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
@@ -68,22 +68,18 @@ alloy:
         		source_labels = ["__meta_kubernetes_pod_node_name"]
         		target_label  = "node"
         	}
-        
         	rule {
-        		source_labels = ["instance"]
-        		regex         = "(.+)/.+"
+        		source_labels = ["__meta_kubernetes_namespace"]
         		target_label  = "namespace"
         	}
         
         	rule {
-        		source_labels = ["instance"]
-        		regex         = ".+/(.+):.+"
+        		source_labels = ["__meta_kubernetes_pod_name"]
         		target_label  = "pod"
         	}
         
         	rule {
-        		source_labels = ["instance"]
-        		regex         = ".+/.+:(.+)"
+        		source_labels = ["__meta_kubernetes_pod_container_name"]
         		target_label  = "container"
         	}
         	rule {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
@@ -70,17 +70,20 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_namespace"]
+        		source_labels = ["instance"]
+        		regex         = "(.+)/.+"
         		target_label  = "namespace"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/(.+):.+"
         		target_label  = "pod"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_container_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/.+:(.+)"
         		target_label  = "container"
         	}
         	rule {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
@@ -62,7 +62,6 @@ alloy:
         		source_labels = ["__meta_kubernetes_pod_node_name"]
         		target_label  = "node"
         	}
-        
         	rule {
         		source_labels = ["instance"]
         		regex         = "(.+)/.+"

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
@@ -64,17 +64,20 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_namespace"]
+        		source_labels = ["instance"]
+        		regex         = "(.+)/.+"
         		target_label  = "namespace"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/(.+):.+"
         		target_label  = "pod"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_container_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/.+:(.+)"
         		target_label  = "container"
         	}
         	rule {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
@@ -62,7 +62,6 @@ alloy:
         		source_labels = ["__meta_kubernetes_pod_node_name"]
         		target_label  = "node"
         	}
-        
         	rule {
         		source_labels = ["instance"]
         		regex         = "(.+)/.+"

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
@@ -64,17 +64,20 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_namespace"]
+        		source_labels = ["instance"]
+        		regex         = "(.+)/.+"
         		target_label  = "namespace"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/(.+):.+"
         		target_label  = "pod"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_container_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/.+:(.+)"
         		target_label  = "container"
         	}
         	rule {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
@@ -62,7 +62,6 @@ alloy:
         		source_labels = ["__meta_kubernetes_pod_node_name"]
         		target_label  = "node"
         	}
-        
         	rule {
         		source_labels = ["instance"]
         		regex         = "(.+)/.+"

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
@@ -64,17 +64,20 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_namespace"]
+        		source_labels = ["instance"]
+        		regex         = "(.+)/.+"
         		target_label  = "namespace"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/(.+):.+"
         		target_label  = "pod"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_container_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/.+:(.+)"
         		target_label  = "container"
         	}
         	rule {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
@@ -62,7 +62,6 @@ alloy:
         		source_labels = ["__meta_kubernetes_pod_node_name"]
         		target_label  = "node"
         	}
-        
         	rule {
         		source_labels = ["instance"]
         		regex         = "(.+)/.+"

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
@@ -64,17 +64,20 @@ alloy:
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_namespace"]
+        		source_labels = ["instance"]
+        		regex         = "(.+)/.+"
         		target_label  = "namespace"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/(.+):.+"
         		target_label  = "pod"
         	}
         
         	rule {
-        		source_labels = ["__meta_kubernetes_pod_container_name"]
+        		source_labels = ["instance"]
+        		regex         = ".+/.+:(.+)"
         		target_label  = "container"
         	}
         	rule {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3855

This PR fixes the namespace, pod, and container label shown in logs.

It does so by extracting those values from the `instance` label which is in the form of `<namespace>/<pod>:<container>`.

![image](https://github.com/user-attachments/assets/2eec5a45-8c60-42cf-840e-d1659a45c03c)
