### PR TITLE
add namespace selector to alloy podlog (workaround for cluster mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `grafana-organization-reconciler` to be used for tenant governance.
 
+### Fixed
+
+- Added a `namespace_selector` to alloy logs config to work around a bug in Alloy 1.5.0 where clustering may not work.
+
 ## [0.22.0] - 2025-02-12
 
 ### Changed

--- a/pkg/resource/logging-config/alloy/logging.alloy.template
+++ b/pkg/resource/logging-config/alloy/logging.alloy.template
@@ -7,7 +7,14 @@ remote.kubernetes.secret "credentials" {
 {{- if .SupportPodLogs }}
 loki.source.podlogs "kubernetes_pods" {
 	forward_to      = [loki.relabel.kubernetes_pods.receiver]
-
+	// namespace_selector is a workaround for broken cluster mode in alloy 1.5.0
+	namespace_selector {
+		match_expression {
+			key = "nonexisting"
+			operator = "NotIn"
+			values = ["nonexistant"]
+		}
+	}
 	clustering {
 		enabled = true
 	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
@@ -20,7 +20,14 @@ alloy:
         // Kubernetes pods logs
         loki.source.podlogs "kubernetes_pods" {
         	forward_to      = [loki.relabel.kubernetes_pods.receiver]
-        
+        	// namespace_selector is a workaround for broken cluster mode in alloy 1.5.0
+        	namespace_selector {
+        		match_expression {
+        			key = "nonexisting"
+        			operator = "NotIn"
+        			values = ["nonexistant"]
+        		}
+        	}
         	clustering {
         		enabled = true
         	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
@@ -20,7 +20,14 @@ alloy:
         // Kubernetes pods logs
         loki.source.podlogs "kubernetes_pods" {
         	forward_to      = [loki.relabel.kubernetes_pods.receiver]
-        
+        	// namespace_selector is a workaround for broken cluster mode in alloy 1.5.0
+        	namespace_selector {
+        		match_expression {
+        			key = "nonexisting"
+        			operator = "NotIn"
+        			values = ["nonexistant"]
+        		}
+        	}
         	clustering {
         		enabled = true
         	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
@@ -20,7 +20,14 @@ alloy:
         // Kubernetes pods logs
         loki.source.podlogs "kubernetes_pods" {
         	forward_to      = [loki.relabel.kubernetes_pods.receiver]
-        
+        	// namespace_selector is a workaround for broken cluster mode in alloy 1.5.0
+        	namespace_selector {
+        		match_expression {
+        			key = "nonexisting"
+        			operator = "NotIn"
+        			values = ["nonexistant"]
+        		}
+        	}
         	clustering {
         		enabled = true
         	}

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
@@ -20,7 +20,14 @@ alloy:
         // Kubernetes pods logs
         loki.source.podlogs "kubernetes_pods" {
         	forward_to      = [loki.relabel.kubernetes_pods.receiver]
-        
+        	// namespace_selector is a workaround for broken cluster mode in alloy 1.5.0
+        	namespace_selector {
+        		match_expression {
+        			key = "nonexisting"
+        			operator = "NotIn"
+        			values = ["nonexistant"]
+        		}
+        	}
         	clustering {
         		enabled = true
         	}


### PR DESCRIPTION
### What this PR does / why we need it

We discovered there's a bug in alloy 1.5.0 (which is currently included in our latest giantswarm platform releases) that breaks clustering when there is no `selector` or `namespace_selector`.

This config change will work around the bug and ensure clustering works with Alloy-logs.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
