### PR TITLE
simplify-dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add tenant filtering in Alloy config
 
+### Changed
+
+- Use smaller dockerfile to reduce build time as ABS already generates the go binary.
+
 ### Fixed
 
 - Fix non-working log lines dropping on missing tenant id

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,9 @@
-# Build the logging-operator binary
-FROM golang:1.24 as builder
-ARG TARGETOS
-ARG TARGETARCH
+FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm
 
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY internal/ internal/
-COPY pkg/ pkg/
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o logging-operator main.go
-
-# Use distroless as minimal base image to package the logging-operator binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/logging-operator .
+
+ADD logging-operator logging-operator
+
 USER 65532:65532
 
 ENTRYPOINT ["/logging-operator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM gsoci.azurecr.io/giantswarm/alpine:3.20.3-giantswarm
-
+# Use distroless as minimal base image to package the logging-operator binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 
 ADD logging-operator logging-operator


### PR DESCRIPTION
### What this PR does / why we need it

This PR is an attempt to use a simpler dockerfile to reduce operator build time as we in fact generate the binary twice (once with abs and once within the docker container)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
