### PR TITLE
Filter out tenants from GrafanaOrganization being deleted

### DIFF
--- a/pkg/resource/logging-config/logging-config.go
+++ b/pkg/resource/logging-config/logging-config.go
@@ -77,6 +77,10 @@ func listTenants(k8sClient client.Client, ctx context.Context) ([]string, error)
 	}
 
 	for _, organization := range grafanaOrganizations.Items {
+		if !organization.DeletionTimestamp.IsZero() {
+			continue
+		}
+
 		for _, tenant := range organization.Spec.Tenants {
 			if !slices.Contains(tenants, string(tenant)) {
 				tenants = append(tenants, string(tenant))


### PR DESCRIPTION
This PR improve the gathering of tenants id by excluding those contained in GrafanaOrganization being deleted.