### PR TITLE
Only fetch tenant IDs on CAPI clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Only fetch tenant IDs on CAPI clusters.
+
 ## [0.24.0] - 2025-03-06
 
 ### Added

--- a/pkg/resource/logging-config/reconciler.go
+++ b/pkg/resource/logging-config/reconciler.go
@@ -42,9 +42,12 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	}
 
 	// Get list of tenants
-	tenants, err := listTenants(r.Client, ctx)
-	if err != nil {
-		return ctrl.Result{}, errors.WithStack(err)
+	var tenants = []string{}
+	if lc.IsCAPI() {
+		tenants, err = listTenants(r.Client, ctx)
+		if err != nil {
+			return ctrl.Result{}, errors.WithStack(err)
+		}
 	}
 
 	// Get desired config


### PR DESCRIPTION
Fix the following error due to non-existing GrafanaOrganization CRD on vintage installations

```
no matches for kind "GrafanaOrganization" in version "observability.giantswarm.io/v1alpha1"
```