### PR TITLE
quick fix promtail agent config issues with the grafana org reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Make sure we use the correct agent in the grafana org reconciler to avoid creating the alloy config for promtail agents.
+
 ## [0.24.1] - 2025-03-06
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -245,6 +245,7 @@ func main() {
 			Client:                  mgr.GetClient(),
 			Scheme:                  mgr.GetScheme(),
 			LoggingConfigReconciler: loggingConfig,
+			AgentsToggleReconciler:  agentsToggle,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create GrafanaOrganization controller", "controller", "GrafanaOrganization")
 			os.Exit(1)

--- a/pkg/resource/logging-config/logging-config.go
+++ b/pkg/resource/logging-config/logging-config.go
@@ -77,10 +77,6 @@ func listTenants(k8sClient client.Client, ctx context.Context) ([]string, error)
 	}
 
 	for _, organization := range grafanaOrganizations.Items {
-		if !organization.DeletionTimestamp.IsZero() {
-			continue
-		}
-
 		for _, tenant := range organization.Spec.Tenants {
 			if !slices.Contains(tenants, string(tenant)) {
 				tenants = append(tenants, string(tenant))


### PR DESCRIPTION
### What this PR does / why we need it

This PR is q temporary fix used in an attempt to fix an ongoing incident.

This fixes the grafana org reconcilier to make sure that the correct logging agent is used to generate the template otherwise we configure promtail with alloy config and that just does not work

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
