### PR TITLE
fix alloy-logs schema-violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix alloy logs schema violations because cpu limit was not a string.
+
 ## [0.26.0] - 2025-03-24
 
 ### Changed

--- a/pkg/resource/logging-config/alloy/logging-config.alloy.yaml.template
+++ b/pkg/resource/logging-config/alloy/logging-config.alloy.yaml.template
@@ -36,7 +36,7 @@ alloy:
     # We decided to configure the alloy-logs resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655
     resources:
       limits:
-        cpu: 2
+        cpu: 2000m
         memory: 300Mi
       requests:
         cpu: 25m

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
@@ -320,7 +320,7 @@ alloy:
     # We decided to configure the alloy-logs resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655
     resources:
       limits:
-        cpu: 2
+        cpu: 2000m
         memory: 300Mi
       requests:
         cpu: 25m

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
@@ -325,7 +325,7 @@ alloy:
     # We decided to configure the alloy-logs resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655
     resources:
       limits:
-        cpu: 2
+        cpu: 2000m
         memory: 300Mi
       requests:
         cpu: 25m

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
@@ -332,7 +332,7 @@ alloy:
     # We decided to configure the alloy-logs resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655
     resources:
       limits:
-        cpu: 2
+        cpu: 2000m
         memory: 300Mi
       requests:
         cpu: 25m

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
@@ -332,7 +332,7 @@ alloy:
     # We decided to configure the alloy-logs resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655
     resources:
       limits:
-        cpu: 2
+        cpu: 2000m
         memory: 300Mi
       requests:
         cpu: 25m

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_custom_tenants.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_custom_tenants.yaml
@@ -332,7 +332,7 @@ alloy:
     # We decided to configure the alloy-logs resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655
     resources:
       limits:
-        cpu: 2
+        cpu: 2000m
         memory: 300Mi
       requests:
         cpu: 25m

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
@@ -332,7 +332,7 @@ alloy:
     # We decided to configure the alloy-logs resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655
     resources:
       limits:
-        cpu: 2
+        cpu: 2000m
         memory: 300Mi
       requests:
         cpu: 25m

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
@@ -332,7 +332,7 @@ alloy:
     # We decided to configure the alloy-logs resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655
     resources:
       limits:
-        cpu: 2
+        cpu: 2000m
         memory: 300Mi
       requests:
         cpu: 25m


### PR DESCRIPTION
### What this PR does / why we need it

This PR fixes the schema violation because cpu must be set as a string instead of an integer

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
