### PR TITLE
move log based alerts rule loading from alloy-rules to alloy-logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for loading log-based Prometheus Rules in the Loki Ruler from workload clusters.
+
+### Changed
+
+- Load log-based Prometheus Rules in the Loki Ruler via Alloy Logs instead of Alloy Rules on management clusters.
+
 ## [0.26.1] - 2025-03-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support for loading log-based Prometheus Rules in the Loki Ruler from workload clusters.
-
-### Changed
-
-- Load log-based Prometheus Rules in the Loki Ruler via Alloy Logs instead of Alloy Rules on management clusters.
+- Add support for loading log-based Prometheus Rules in the Loki Ruler from management and workload clusters.
 
 ## [0.26.1] - 2025-03-24
 

--- a/go.mod
+++ b/go.mod
@@ -100,4 +100,7 @@ require (
 replace (
 	github.com/alessio/shellescape => al.essio.dev/pkg/shellescape v1.6.0
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.6
+
+	// Needed to fix CVE CVE-2025-22872 (TODO remove when fixed upstream in github.com/prometheus/common/config)
+	golang.org/x/net v0.37.0 => golang.org/x/net v0.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.37.0 h1:1zLorHbz+LYj7MQlSf1+2tPIIgibq2eL5xkrGk6f+2c=
-golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
 golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
 golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -48,12 +48,14 @@ const (
 	AlloyEventsLoggerAppNamespace = "kube-system"
 
 	MaxBackoffPeriod = "10m"
-	LokiURLFormat    = "https://%s/loki/api/v1/push"
+	LokiBaseURL      = "https://%s"
+	LokiPushURL      = LokiBaseURL + "/loki/api/v1/push"
 
 	LoggingURL      = "logging-url"
 	LoggingTenantID = "logging-tenant-id"
 	LoggingUsername = "logging-username"
 	LoggingPassword = "logging-password"
+	RulerAPIURL     = "ruler-api-url"
 )
 
 func GrafanaAgentExtraSecretName() string {
@@ -76,8 +78,8 @@ func IsWorkloadCluster(lc loggedcluster.Interface) bool {
 	return lc.GetInstallationName() != lc.GetClusterName()
 }
 
-// Read Proxy URL from ingress
-func ReadProxyIngressURL(ctx context.Context, lc loggedcluster.Interface, client client.Client) (string, error) {
+// Read Loki URL from ingress
+func ReadLokiIngressURL(ctx context.Context, lc loggedcluster.Interface, client client.Client) (string, error) {
 	var lokiIngress netv1.Ingress
 
 	var objectKey types.NamespacedName

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -47,15 +47,16 @@ const (
 	AlloyEventsLoggerAppName      = "alloy-events"
 	AlloyEventsLoggerAppNamespace = "kube-system"
 
-	MaxBackoffPeriod = "10m"
-	LokiBaseURL      = "https://%s"
-	LokiPushURL      = LokiBaseURL + "/loki/api/v1/push"
+	MaxBackoffPeriod  = "10m"
+	LokiBaseURLFormat = "https://%s"
+	lokiAPIV1PushPath = "/loki/api/v1/push"
+	LokiPushURLFormat = LokiBaseURLFormat + lokiAPIV1PushPath
 
 	LoggingURL      = "logging-url"
 	LoggingTenantID = "logging-tenant-id"
 	LoggingUsername = "logging-username"
 	LoggingPassword = "logging-password"
-	RulerAPIURL     = "ruler-api-url"
+	LokiRulerAPIURL = "ruler-api-url"
 )
 
 func GrafanaAgentExtraSecretName() string {

--- a/pkg/resource/events-logger-secret/grafana-agent-secret.go
+++ b/pkg/resource/events-logger-secret/grafana-agent-secret.go
@@ -35,7 +35,7 @@ func generateGrafanaAgentSecret(lc loggedcluster.Interface, credentialsSecret *v
 		ExtraSecret: extraSecret{
 			Name: fmt.Sprintf("%s-%s", clusterName, common.GrafanaAgentExtraSecretName()),
 			Data: map[string]string{
-				common.LoggingURL:      fmt.Sprintf(common.LokiURLFormat, lokiURL),
+				common.LoggingURL:      fmt.Sprintf(common.LokiPushURL, lokiURL),
 				common.LoggingTenantID: lc.GetTenant(),
 				common.LoggingUsername: writeUser,
 				common.LoggingPassword: writePassword,

--- a/pkg/resource/events-logger-secret/grafana-agent-secret.go
+++ b/pkg/resource/events-logger-secret/grafana-agent-secret.go
@@ -35,7 +35,7 @@ func generateGrafanaAgentSecret(lc loggedcluster.Interface, credentialsSecret *v
 		ExtraSecret: extraSecret{
 			Name: fmt.Sprintf("%s-%s", clusterName, common.GrafanaAgentExtraSecretName()),
 			Data: map[string]string{
-				common.LoggingURL:      fmt.Sprintf(common.LokiPushURL, lokiURL),
+				common.LoggingURL:      fmt.Sprintf(common.LokiPushURLFormat, lokiURL),
 				common.LoggingTenantID: lc.GetTenant(),
 				common.LoggingUsername: writeUser,
 				common.LoggingPassword: writePassword,

--- a/pkg/resource/events-logger-secret/reconciler.go
+++ b/pkg/resource/events-logger-secret/reconciler.go
@@ -38,7 +38,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	}
 
 	// Retrieve Loki ingress name
-	lokiURL, err := common.ReadProxyIngressURL(ctx, lc, r.Client)
+	lokiURL, err := common.ReadLokiIngressURL(ctx, lc, r.Client)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}

--- a/pkg/resource/logging-config/alloy-logging-config.go
+++ b/pkg/resource/logging-config/alloy-logging-config.go
@@ -78,7 +78,7 @@ func generateAlloyConfig(lc loggedcluster.Interface, observabilityBundleVersion 
 	}
 
 	data := struct {
-		ClusterName        string
+		ClusterID          string
 		Installation       string
 		MaxBackoffPeriod   string
 		IsWorkloadCluster  bool
@@ -89,10 +89,10 @@ func generateAlloyConfig(lc loggedcluster.Interface, observabilityBundleVersion 
 		LoggingTenantIDKey string
 		LoggingUsernameKey string
 		LoggingPasswordKey string
-		RulerAPIURLKey     string
+		LokiRulerAPIURLKey string
 		Tenants            []string
 	}{
-		ClusterName:       clusterName,
+		ClusterID:         clusterName,
 		Installation:      lc.GetInstallationName(),
 		MaxBackoffPeriod:  common.MaxBackoffPeriod,
 		IsWorkloadCluster: common.IsWorkloadCluster(lc),
@@ -104,7 +104,7 @@ func generateAlloyConfig(lc loggedcluster.Interface, observabilityBundleVersion 
 		LoggingTenantIDKey: common.LoggingTenantID,
 		LoggingUsernameKey: common.LoggingUsername,
 		LoggingPasswordKey: common.LoggingPassword,
-		RulerAPIURLKey:     common.RulerAPIURL,
+		LokiRulerAPIURLKey: common.LokiRulerAPIURL,
 		Tenants:            tenants,
 	}
 

--- a/pkg/resource/logging-config/alloy-logging-config.go
+++ b/pkg/resource/logging-config/alloy-logging-config.go
@@ -78,7 +78,7 @@ func generateAlloyConfig(lc loggedcluster.Interface, observabilityBundleVersion 
 	}
 
 	data := struct {
-		ClusterID          string
+		ClusterName        string
 		Installation       string
 		MaxBackoffPeriod   string
 		IsWorkloadCluster  bool
@@ -89,9 +89,10 @@ func generateAlloyConfig(lc loggedcluster.Interface, observabilityBundleVersion 
 		LoggingTenantIDKey string
 		LoggingUsernameKey string
 		LoggingPasswordKey string
+		RulerAPIURLKey     string
 		Tenants            []string
 	}{
-		ClusterID:         clusterName,
+		ClusterName:       clusterName,
 		Installation:      lc.GetInstallationName(),
 		MaxBackoffPeriod:  common.MaxBackoffPeriod,
 		IsWorkloadCluster: common.IsWorkloadCluster(lc),
@@ -103,6 +104,7 @@ func generateAlloyConfig(lc loggedcluster.Interface, observabilityBundleVersion 
 		LoggingTenantIDKey: common.LoggingTenantID,
 		LoggingUsernameKey: common.LoggingUsername,
 		LoggingPasswordKey: common.LoggingPassword,
+		RulerAPIURLKey:     common.RulerAPIURL,
 		Tenants:            tenants,
 	}
 

--- a/pkg/resource/logging-config/alloy/logging-config.alloy.yaml.template
+++ b/pkg/resource/logging-config/alloy/logging-config.alloy.yaml.template
@@ -7,6 +7,41 @@
 # - Running as root user is required in order to be able to read log files within
 #   /var/log/journal and /run/log/journal directories.
 # - NODENAME env var is used as additional label for kubernetes_audit logs.
+networkPolicy:
+  cilium:
+    egress:
+    - toEntities:
+      - kube-apiserver
+      - world
+    - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
+      toPorts:
+      - ports:
+        - port: "1053"
+          protocol: UDP
+        - port: "1053"
+          protocol: TCP
+        - port: "53"
+          protocol: UDP
+        - port: "53"
+          protocol: TCP
+    {{- if not .IsWorkloadCluster }}
+    - toEndpoints:
+      - matchLabels:
+          app.kubernetes.io/component: backend
+          app.kubernetes.io/name: loki
+          io.kubernetes.pod.namespace: loki
+      toPorts:
+      - ports:
+        - port: "3100"
+          protocol: TCP
+    {{- end }}
+
 alloy:
   alloy:
     configMap:

--- a/pkg/resource/logging-config/alloy/logging.alloy.template
+++ b/pkg/resource/logging-config/alloy/logging.alloy.template
@@ -12,7 +12,7 @@ remote.kubernetes.secret "credentials" {
 // load rules for tenant {{ . }}
 loki.rules.kubernetes "{{ . }}" {
 	{{- if $.IsWorkloadCluster }}
-	address = remote.kubernetes.secret.credentials.data["{{ $.RulerAPIURLKey }}"]
+	address = nonsensitive(remote.kubernetes.secret.credentials.data["{{ $.LokiRulerAPIURLKey }}"])
 	basic_auth {
 		username = nonsensitive(remote.kubernetes.secret.credentials.data["{{ $.LoggingUsernameKey }}"])
 		password = remote.kubernetes.secret.credentials.data["{{ $.LoggingPasswordKey }}"]
@@ -20,7 +20,7 @@ loki.rules.kubernetes "{{ . }}" {
 	{{- else }}
 	address = "http://loki-backend.loki.svc:3100/"
 	{{- end }}
-	loki_namespace_prefix = "{{ $.ClusterName }}"
+	loki_namespace_prefix = "{{ $.ClusterID }}"
 	tenant_id = "{{ . }}"
 	rule_selector {
 		match_labels = {
@@ -386,7 +386,7 @@ loki.write "default" {
 		}
 	}
 	external_labels = {
-		cluster_id   = "{{ .ClusterName }}",
+		cluster_id   = "{{ .ClusterID }}",
 		installation = "{{ .Installation }}",
 	}
 }

--- a/pkg/resource/logging-config/alloy/logging.alloy.template
+++ b/pkg/resource/logging-config/alloy/logging.alloy.template
@@ -1,7 +1,39 @@
+logging {
+	level  = "warn"
+	format = "logfmt"
+}
+
 remote.kubernetes.secret "credentials" {
 	namespace = "kube-system"
 	name = "{{ .SecretName }}"
 }
+
+{{- range .Tenants }}
+// load rules for tenant {{ . }}
+loki.rules.kubernetes "{{ . }}" {
+	{{- if $.IsWorkloadCluster }}
+	address = remote.kubernetes.secret.credentials.data["{{ $.RulerAPIURLKey }}"]
+	basic_auth {
+		username = nonsensitive(remote.kubernetes.secret.credentials.data["{{ $.LoggingUsernameKey }}"])
+		password = remote.kubernetes.secret.credentials.data["{{ $.LoggingPasswordKey }}"]
+	}
+	{{- else }}
+	address = "http://loki-backend.loki.svc:3100/"
+	{{- end }}
+	loki_namespace_prefix = "{{ $.ClusterName }}"
+	tenant_id = "{{ . }}"
+	rule_selector {
+		match_labels = {
+			"observability.giantswarm.io/tenant" = "{{ . }}",
+		}
+		match_expression {
+			key = "application.giantswarm.io/prometheus-rule-kind"
+			operator = "In"
+			values = ["loki"]
+		}
+	}
+}
+{{- end }}
 
 // Kubernetes pods logs
 {{- if .SupportPodLogs }}
@@ -354,12 +386,7 @@ loki.write "default" {
 		}
 	}
 	external_labels = {
-		cluster_id   = "{{ .ClusterID }}",
+		cluster_id   = "{{ .ClusterName }}",
 		installation = "{{ .Installation }}",
 	}
-}
-
-logging {
-	level  = "warn"
-	format = "logfmt"
 }

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
@@ -7,14 +7,68 @@
 # - Running as root user is required in order to be able to read log files within
 #   /var/log/journal and /run/log/journal directories.
 # - NODENAME env var is used as additional label for kubernetes_audit logs.
+networkPolicy:
+  cilium:
+    egress:
+    - toEntities:
+      - kube-apiserver
+      - world
+    - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
+      toPorts:
+      - ports:
+        - port: "1053"
+          protocol: UDP
+        - port: "1053"
+          protocol: TCP
+        - port: "53"
+          protocol: UDP
+        - port: "53"
+          protocol: TCP
+    - toEndpoints:
+      - matchLabels:
+          app.kubernetes.io/component: backend
+          app.kubernetes.io/name: loki
+          io.kubernetes.pod.namespace: loki
+      toPorts:
+      - ports:
+        - port: "3100"
+          protocol: TCP
+
 alloy:
   alloy:
     configMap:
       create: true
       content: |-
+        logging {
+        	level  = "warn"
+        	format = "logfmt"
+        }
+        
         remote.kubernetes.secret "credentials" {
         	namespace = "kube-system"
         	name = "alloy-logs"
+        }
+        // load rules for tenant giantswarm
+        loki.rules.kubernetes "giantswarm" {
+        	address = "http://loki-backend.loki.svc:3100/"
+        	loki_namespace_prefix = "test-installation"
+        	tenant_id = "giantswarm"
+        	rule_selector {
+        		match_labels = {
+        			"observability.giantswarm.io/tenant" = "giantswarm",
+        		}
+        		match_expression {
+        			key = "application.giantswarm.io/prometheus-rule-kind"
+        			operator = "In"
+        			values = ["loki"]
+        		}
+        	}
         }
         
         // Kubernetes pods logs
@@ -295,11 +349,6 @@ alloy:
         		cluster_id   = "test-installation",
         		installation = "test-installation",
         	}
-        }
-        
-        logging {
-        	level  = "warn"
-        	format = "logfmt"
         }
         
     extraEnv:

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
@@ -7,14 +7,63 @@
 # - Running as root user is required in order to be able to read log files within
 #   /var/log/journal and /run/log/journal directories.
 # - NODENAME env var is used as additional label for kubernetes_audit logs.
+networkPolicy:
+  cilium:
+    egress:
+    - toEntities:
+      - kube-apiserver
+      - world
+    - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
+      toPorts:
+      - ports:
+        - port: "1053"
+          protocol: UDP
+        - port: "1053"
+          protocol: TCP
+        - port: "53"
+          protocol: UDP
+        - port: "53"
+          protocol: TCP
+
 alloy:
   alloy:
     configMap:
       create: true
       content: |-
+        logging {
+        	level  = "warn"
+        	format = "logfmt"
+        }
+        
         remote.kubernetes.secret "credentials" {
         	namespace = "kube-system"
         	name = "alloy-logs"
+        }
+        // load rules for tenant giantswarm
+        loki.rules.kubernetes "giantswarm" {
+        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	basic_auth {
+        		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
+        		password = remote.kubernetes.secret.credentials.data["logging-password"]
+        	}
+        	loki_namespace_prefix = "test-cluster"
+        	tenant_id = "giantswarm"
+        	rule_selector {
+        		match_labels = {
+        			"observability.giantswarm.io/tenant" = "giantswarm",
+        		}
+        		match_expression {
+        			key = "application.giantswarm.io/prometheus-rule-kind"
+        			operator = "In"
+        			values = ["loki"]
+        		}
+        	}
         }
         
         // Kubernetes pods logs
@@ -300,11 +349,6 @@ alloy:
         		cluster_id   = "test-cluster",
         		installation = "test-installation",
         	}
-        }
-        
-        logging {
-        	level  = "warn"
-        	format = "logfmt"
         }
         
     extraEnv:

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
@@ -47,7 +47,7 @@ alloy:
         }
         // load rules for tenant giantswarm
         loki.rules.kubernetes "giantswarm" {
-        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	address = nonsensitive(remote.kubernetes.secret.credentials.data["ruler-api-url"])
         	basic_auth {
         		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
         		password = remote.kubernetes.secret.credentials.data["logging-password"]

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
@@ -7,14 +7,68 @@
 # - Running as root user is required in order to be able to read log files within
 #   /var/log/journal and /run/log/journal directories.
 # - NODENAME env var is used as additional label for kubernetes_audit logs.
+networkPolicy:
+  cilium:
+    egress:
+    - toEntities:
+      - kube-apiserver
+      - world
+    - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
+      toPorts:
+      - ports:
+        - port: "1053"
+          protocol: UDP
+        - port: "1053"
+          protocol: TCP
+        - port: "53"
+          protocol: UDP
+        - port: "53"
+          protocol: TCP
+    - toEndpoints:
+      - matchLabels:
+          app.kubernetes.io/component: backend
+          app.kubernetes.io/name: loki
+          io.kubernetes.pod.namespace: loki
+      toPorts:
+      - ports:
+        - port: "3100"
+          protocol: TCP
+
 alloy:
   alloy:
     configMap:
       create: true
       content: |-
+        logging {
+        	level  = "warn"
+        	format = "logfmt"
+        }
+        
         remote.kubernetes.secret "credentials" {
         	namespace = "kube-system"
         	name = "alloy-logs"
+        }
+        // load rules for tenant giantswarm
+        loki.rules.kubernetes "giantswarm" {
+        	address = "http://loki-backend.loki.svc:3100/"
+        	loki_namespace_prefix = "test-installation"
+        	tenant_id = "giantswarm"
+        	rule_selector {
+        		match_labels = {
+        			"observability.giantswarm.io/tenant" = "giantswarm",
+        		}
+        		match_expression {
+        			key = "application.giantswarm.io/prometheus-rule-kind"
+        			operator = "In"
+        			values = ["loki"]
+        		}
+        	}
         }
         
         // Kubernetes pods logs
@@ -304,11 +358,6 @@ alloy:
         		cluster_id   = "test-installation",
         		installation = "test-installation",
         	}
-        }
-        
-        logging {
-        	level  = "warn"
-        	format = "logfmt"
         }
         
     clustering:

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
@@ -7,14 +7,63 @@
 # - Running as root user is required in order to be able to read log files within
 #   /var/log/journal and /run/log/journal directories.
 # - NODENAME env var is used as additional label for kubernetes_audit logs.
+networkPolicy:
+  cilium:
+    egress:
+    - toEntities:
+      - kube-apiserver
+      - world
+    - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
+      toPorts:
+      - ports:
+        - port: "1053"
+          protocol: UDP
+        - port: "1053"
+          protocol: TCP
+        - port: "53"
+          protocol: UDP
+        - port: "53"
+          protocol: TCP
+
 alloy:
   alloy:
     configMap:
       create: true
       content: |-
+        logging {
+        	level  = "warn"
+        	format = "logfmt"
+        }
+        
         remote.kubernetes.secret "credentials" {
         	namespace = "kube-system"
         	name = "alloy-logs"
+        }
+        // load rules for tenant giantswarm
+        loki.rules.kubernetes "giantswarm" {
+        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	basic_auth {
+        		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
+        		password = remote.kubernetes.secret.credentials.data["logging-password"]
+        	}
+        	loki_namespace_prefix = "test-cluster"
+        	tenant_id = "giantswarm"
+        	rule_selector {
+        		match_labels = {
+        			"observability.giantswarm.io/tenant" = "giantswarm",
+        		}
+        		match_expression {
+        			key = "application.giantswarm.io/prometheus-rule-kind"
+        			operator = "In"
+        			values = ["loki"]
+        		}
+        	}
         }
         
         // Kubernetes pods logs
@@ -304,11 +353,6 @@ alloy:
         		cluster_id   = "test-cluster",
         		installation = "test-installation",
         	}
-        }
-        
-        logging {
-        	level  = "warn"
-        	format = "logfmt"
         }
         
     clustering:

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
@@ -47,7 +47,7 @@ alloy:
         }
         // load rules for tenant giantswarm
         loki.rules.kubernetes "giantswarm" {
-        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	address = nonsensitive(remote.kubernetes.secret.credentials.data["ruler-api-url"])
         	basic_auth {
         		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
         		password = remote.kubernetes.secret.credentials.data["logging-password"]

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_custom_tenants.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_custom_tenants.yaml
@@ -47,7 +47,7 @@ alloy:
         }
         // load rules for tenant test-tenant-a
         loki.rules.kubernetes "test-tenant-a" {
-        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	address = nonsensitive(remote.kubernetes.secret.credentials.data["ruler-api-url"])
         	basic_auth {
         		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
         		password = remote.kubernetes.secret.credentials.data["logging-password"]
@@ -67,7 +67,7 @@ alloy:
         }
         // load rules for tenant test-tenant-b
         loki.rules.kubernetes "test-tenant-b" {
-        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	address = nonsensitive(remote.kubernetes.secret.credentials.data["ruler-api-url"])
         	basic_auth {
         		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
         		password = remote.kubernetes.secret.credentials.data["logging-password"]
@@ -87,7 +87,7 @@ alloy:
         }
         // load rules for tenant giantswarm
         loki.rules.kubernetes "giantswarm" {
-        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	address = nonsensitive(remote.kubernetes.secret.credentials.data["ruler-api-url"])
         	basic_auth {
         		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
         		password = remote.kubernetes.secret.credentials.data["logging-password"]

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_custom_tenants.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_custom_tenants.yaml
@@ -7,14 +7,103 @@
 # - Running as root user is required in order to be able to read log files within
 #   /var/log/journal and /run/log/journal directories.
 # - NODENAME env var is used as additional label for kubernetes_audit logs.
+networkPolicy:
+  cilium:
+    egress:
+    - toEntities:
+      - kube-apiserver
+      - world
+    - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
+      toPorts:
+      - ports:
+        - port: "1053"
+          protocol: UDP
+        - port: "1053"
+          protocol: TCP
+        - port: "53"
+          protocol: UDP
+        - port: "53"
+          protocol: TCP
+
 alloy:
   alloy:
     configMap:
       create: true
       content: |-
+        logging {
+        	level  = "warn"
+        	format = "logfmt"
+        }
+        
         remote.kubernetes.secret "credentials" {
         	namespace = "kube-system"
         	name = "alloy-logs"
+        }
+        // load rules for tenant test-tenant-a
+        loki.rules.kubernetes "test-tenant-a" {
+        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	basic_auth {
+        		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
+        		password = remote.kubernetes.secret.credentials.data["logging-password"]
+        	}
+        	loki_namespace_prefix = "test-cluster"
+        	tenant_id = "test-tenant-a"
+        	rule_selector {
+        		match_labels = {
+        			"observability.giantswarm.io/tenant" = "test-tenant-a",
+        		}
+        		match_expression {
+        			key = "application.giantswarm.io/prometheus-rule-kind"
+        			operator = "In"
+        			values = ["loki"]
+        		}
+        	}
+        }
+        // load rules for tenant test-tenant-b
+        loki.rules.kubernetes "test-tenant-b" {
+        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	basic_auth {
+        		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
+        		password = remote.kubernetes.secret.credentials.data["logging-password"]
+        	}
+        	loki_namespace_prefix = "test-cluster"
+        	tenant_id = "test-tenant-b"
+        	rule_selector {
+        		match_labels = {
+        			"observability.giantswarm.io/tenant" = "test-tenant-b",
+        		}
+        		match_expression {
+        			key = "application.giantswarm.io/prometheus-rule-kind"
+        			operator = "In"
+        			values = ["loki"]
+        		}
+        	}
+        }
+        // load rules for tenant giantswarm
+        loki.rules.kubernetes "giantswarm" {
+        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	basic_auth {
+        		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
+        		password = remote.kubernetes.secret.credentials.data["logging-password"]
+        	}
+        	loki_namespace_prefix = "test-cluster"
+        	tenant_id = "giantswarm"
+        	rule_selector {
+        		match_labels = {
+        			"observability.giantswarm.io/tenant" = "giantswarm",
+        		}
+        		match_expression {
+        			key = "application.giantswarm.io/prometheus-rule-kind"
+        			operator = "In"
+        			values = ["loki"]
+        		}
+        	}
         }
         
         // Kubernetes pods logs
@@ -304,11 +393,6 @@ alloy:
         		cluster_id   = "test-cluster",
         		installation = "test-installation",
         	}
-        }
-        
-        logging {
-        	level  = "warn"
-        	format = "logfmt"
         }
         
     clustering:

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
@@ -7,14 +7,63 @@
 # - Running as root user is required in order to be able to read log files within
 #   /var/log/journal and /run/log/journal directories.
 # - NODENAME env var is used as additional label for kubernetes_audit logs.
+networkPolicy:
+  cilium:
+    egress:
+    - toEntities:
+      - kube-apiserver
+      - world
+    - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
+      toPorts:
+      - ports:
+        - port: "1053"
+          protocol: UDP
+        - port: "1053"
+          protocol: TCP
+        - port: "53"
+          protocol: UDP
+        - port: "53"
+          protocol: TCP
+
 alloy:
   alloy:
     configMap:
       create: true
       content: |-
+        logging {
+        	level  = "warn"
+        	format = "logfmt"
+        }
+        
         remote.kubernetes.secret "credentials" {
         	namespace = "kube-system"
         	name = "alloy-logs"
+        }
+        // load rules for tenant giantswarm
+        loki.rules.kubernetes "giantswarm" {
+        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	basic_auth {
+        		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
+        		password = remote.kubernetes.secret.credentials.data["logging-password"]
+        	}
+        	loki_namespace_prefix = "test-cluster"
+        	tenant_id = "giantswarm"
+        	rule_selector {
+        		match_labels = {
+        			"observability.giantswarm.io/tenant" = "giantswarm",
+        		}
+        		match_expression {
+        			key = "application.giantswarm.io/prometheus-rule-kind"
+        			operator = "In"
+        			values = ["loki"]
+        		}
+        	}
         }
         
         // Kubernetes pods logs
@@ -304,11 +353,6 @@ alloy:
         		cluster_id   = "test-cluster",
         		installation = "test-installation",
         	}
-        }
-        
-        logging {
-        	level  = "warn"
-        	format = "logfmt"
         }
         
     clustering:

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
@@ -47,7 +47,7 @@ alloy:
         }
         // load rules for tenant giantswarm
         loki.rules.kubernetes "giantswarm" {
-        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	address = nonsensitive(remote.kubernetes.secret.credentials.data["ruler-api-url"])
         	basic_auth {
         		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
         		password = remote.kubernetes.secret.credentials.data["logging-password"]

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
@@ -7,14 +7,63 @@
 # - Running as root user is required in order to be able to read log files within
 #   /var/log/journal and /run/log/journal directories.
 # - NODENAME env var is used as additional label for kubernetes_audit logs.
+networkPolicy:
+  cilium:
+    egress:
+    - toEntities:
+      - kube-apiserver
+      - world
+    - toEndpoints:
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: coredns
+      - matchLabels:
+          io.kubernetes.pod.namespace: kube-system
+          k8s-app: k8s-dns-node-cache
+      toPorts:
+      - ports:
+        - port: "1053"
+          protocol: UDP
+        - port: "1053"
+          protocol: TCP
+        - port: "53"
+          protocol: UDP
+        - port: "53"
+          protocol: TCP
+
 alloy:
   alloy:
     configMap:
       create: true
       content: |-
+        logging {
+        	level  = "warn"
+        	format = "logfmt"
+        }
+        
         remote.kubernetes.secret "credentials" {
         	namespace = "kube-system"
         	name = "alloy-logs"
+        }
+        // load rules for tenant giantswarm
+        loki.rules.kubernetes "giantswarm" {
+        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	basic_auth {
+        		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
+        		password = remote.kubernetes.secret.credentials.data["logging-password"]
+        	}
+        	loki_namespace_prefix = "test-cluster"
+        	tenant_id = "giantswarm"
+        	rule_selector {
+        		match_labels = {
+        			"observability.giantswarm.io/tenant" = "giantswarm",
+        		}
+        		match_expression {
+        			key = "application.giantswarm.io/prometheus-rule-kind"
+        			operator = "In"
+        			values = ["loki"]
+        		}
+        	}
         }
         
         // Kubernetes pods logs
@@ -304,11 +353,6 @@ alloy:
         		cluster_id   = "test-cluster",
         		installation = "test-installation",
         	}
-        }
-        
-        logging {
-        	level  = "warn"
-        	format = "logfmt"
         }
         
     clustering:

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
@@ -47,7 +47,7 @@ alloy:
         }
         // load rules for tenant giantswarm
         loki.rules.kubernetes "giantswarm" {
-        	address = remote.kubernetes.secret.credentials.data["ruler-api-url"]
+        	address = nonsensitive(remote.kubernetes.secret.credentials.data["ruler-api-url"])
         	basic_auth {
         		username = nonsensitive(remote.kubernetes.secret.credentials.data["logging-username"])
         		password = remote.kubernetes.secret.credentials.data["logging-password"]

--- a/pkg/resource/logging-secret/alloy-logging-secret.go
+++ b/pkg/resource/logging-secret/alloy-logging-secret.go
@@ -37,11 +37,11 @@ func GenerateAlloyLoggingSecret(lc loggedcluster.Interface, credentialsSecret *v
 		ExtraSecretEnv map[string]string
 	}{
 		ExtraSecretEnv: map[string]string{
-			common.LoggingURL:      fmt.Sprintf(common.LokiPushURL, lokiURL),
+			common.LoggingURL:      fmt.Sprintf(common.LokiPushURLFormat, lokiURL),
 			common.LoggingTenantID: lc.GetTenant(),
 			common.LoggingUsername: clusterName,
 			common.LoggingPassword: writePassword,
-			common.RulerAPIURL:     fmt.Sprintf(common.LokiBaseURL, lokiURL),
+			common.LokiRulerAPIURL: fmt.Sprintf(common.LokiBaseURLFormat, lokiURL),
 		},
 	}
 

--- a/pkg/resource/logging-secret/alloy-logging-secret.go
+++ b/pkg/resource/logging-secret/alloy-logging-secret.go
@@ -37,10 +37,11 @@ func GenerateAlloyLoggingSecret(lc loggedcluster.Interface, credentialsSecret *v
 		ExtraSecretEnv map[string]string
 	}{
 		ExtraSecretEnv: map[string]string{
-			common.LoggingURL:      fmt.Sprintf(common.LokiURLFormat, lokiURL),
+			common.LoggingURL:      fmt.Sprintf(common.LokiPushURL, lokiURL),
 			common.LoggingTenantID: lc.GetTenant(),
 			common.LoggingUsername: clusterName,
 			common.LoggingPassword: writePassword,
+			common.RulerAPIURL:     fmt.Sprintf(common.LokiBaseURL, lokiURL),
 		},
 	}
 

--- a/pkg/resource/logging-secret/promtail-logging-secret.go
+++ b/pkg/resource/logging-secret/promtail-logging-secret.go
@@ -69,7 +69,7 @@ func GeneratePromtailLoggingSecret(lc loggedcluster.Interface, credentialsSecret
 			Config: promtailConfig{
 				Clients: []promtailConfigClient{
 					{
-						URL:      fmt.Sprintf(common.LokiPushURL, lokiURL),
+						URL:      fmt.Sprintf(common.LokiPushURLFormat, lokiURL),
 						TenantID: lc.GetTenant(),
 						BasicAuth: promtailConfigClientBasicAuth{
 							Username: writeUser,

--- a/pkg/resource/logging-secret/promtail-logging-secret.go
+++ b/pkg/resource/logging-secret/promtail-logging-secret.go
@@ -69,7 +69,7 @@ func GeneratePromtailLoggingSecret(lc loggedcluster.Interface, credentialsSecret
 			Config: promtailConfig{
 				Clients: []promtailConfigClient{
 					{
-						URL:      fmt.Sprintf(common.LokiURLFormat, lokiURL),
+						URL:      fmt.Sprintf(common.LokiPushURL, lokiURL),
 						TenantID: lc.GetTenant(),
 						BasicAuth: promtailConfigClientBasicAuth{
 							Username: writeUser,

--- a/pkg/resource/logging-secret/reconciler.go
+++ b/pkg/resource/logging-secret/reconciler.go
@@ -38,7 +38,7 @@ func (r *Reconciler) ReconcileCreate(ctx context.Context, lc loggedcluster.Inter
 	}
 
 	// Retrieve Loki ingress name
-	lokiURL, err := common.ReadProxyIngressURL(ctx, lc, r.Client)
+	lokiURL, err := common.ReadLokiIngressURL(ctx, lc, r.Client)
 	if err != nil {
 		return ctrl.Result{}, errors.WithStack(err)
 	}


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/3986

This pull request introduces changes to support loading prometheus rules in a tenant in the Mimir Ruler from `Workload Clusters` via alloy-logs. It is based on the change introduced in the observability operator in this PR: https://github.com/giantswarm/observability-operator/pull/353

It also adds support for loading prometheus rules in a tenant in the Loki Ruler from `Management Clusters` via alloy-logs. It is based on https://github.com/giantswarm/observability-operator/pull/354.

Now rules will be loaded into the cluster name prefix from both management cluster and workload clusters.

The main differences with the observability operator changes are that:
- `loki.rules.kubernetes` does not currently support extraQueryMatchers but we don't really expect to have a lot of log based alerts (and upstream PR is waiting for review https://github.com/grafana/alloy/pull/3373)
- disabling of loading via alloy-rules needs is done in the observability operator and not here so the 2 release will need to be done close to the other so most likely not before tuesday the 22nd :D (we have only 2 log based alerts so it's not really that problematic if they do not page during easter but still, releases will wait)

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
