### PR TITLE
Increase default loki.write timeouts in all agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update default grafana-agent and alloy-logs timeout to support bigger installations.
+- Introduce the new `remote_timeout` parameter to configure timeouts for remote write operations.
+  This change affects the following agents: `promtail`, `grafana-agent`, `alloy-events`, and `alloy-logs`.
+  The default value has been updated to better support larger installations.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update default grafana-agent and alloy-logs timeout to support bigger installations.
+
 ### Removed
 
 - Remove vintage mode from the operator. This includes the vintage MC and WC reconciliers.

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -45,6 +45,7 @@ const (
 	AlloyEventsLoggerAppName      = "alloy-events"
 	AlloyEventsLoggerAppNamespace = "kube-system"
 
+        // LokiMaxBackoffPeriod specifies the maximum retry backoff duration for Loki writes.
 	LokiMaxBackoffPeriod = 10 * time.Minute
 	LokiRemoteTimeout    = 60 * time.Second
 	LokiBaseURLFormat    = "https://%s"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -48,7 +48,7 @@ const (
         // LokiMaxBackoffPeriod specifies the maximum retry backoff duration for Loki writes.
 	LokiMaxBackoffPeriod = 10 * time.Minute
 	// LokiRemoteTimeout configures the write timeout for remote Loki endpoints.
-	LokiRemoteTimeout    = 60 * time.Second
+	LokiRemoteTimeout = 60 * time.Second
 	LokiBaseURLFormat    = "https://%s"
 	lokiAPIV1PushPath    = "/loki/api/v1/push"
 	LokiPushURLFormat    = LokiBaseURLFormat + lokiAPIV1PushPath

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -45,13 +45,14 @@ const (
 	AlloyEventsLoggerAppName      = "alloy-events"
 	AlloyEventsLoggerAppNamespace = "kube-system"
 
-        // LokiMaxBackoffPeriod specifies the maximum retry backoff duration for Loki writes.
+	// LokiMaxBackoffPeriod specifies the maximum retry backoff duration for Loki writes.
 	LokiMaxBackoffPeriod = 10 * time.Minute
 	// LokiRemoteTimeout configures the write timeout for remote Loki endpoints.
-	LokiRemoteTimeout = 60 * time.Second
-	LokiBaseURLFormat    = "https://%s"
-	lokiAPIV1PushPath    = "/loki/api/v1/push"
-	LokiPushURLFormat    = LokiBaseURLFormat + lokiAPIV1PushPath
+	LokiRemoteTimeout    = 60 * time.Second
+
+	LokiBaseURLFormat = "https://%s"
+	lokiAPIV1PushPath = "/loki/api/v1/push"
+	LokiPushURLFormat = LokiBaseURLFormat + lokiAPIV1PushPath
 
 	LoggingURL      = "logging-url"
 	LoggingTenantID = "logging-tenant-id"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -48,7 +48,7 @@ const (
 	// LokiMaxBackoffPeriod specifies the maximum retry backoff duration for Loki writes.
 	LokiMaxBackoffPeriod = 10 * time.Minute
 	// LokiRemoteTimeout configures the write timeout for remote Loki endpoints.
-	LokiRemoteTimeout    = 60 * time.Second
+	LokiRemoteTimeout = 60 * time.Second
 
 	LokiBaseURLFormat = "https://%s"
 	lokiAPIV1PushPath = "/loki/api/v1/push"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -47,6 +47,7 @@ const (
 
         // LokiMaxBackoffPeriod specifies the maximum retry backoff duration for Loki writes.
 	LokiMaxBackoffPeriod = 10 * time.Minute
+	// LokiRemoteTimeout configures the write timeout for remote Loki endpoints.
 	LokiRemoteTimeout    = 60 * time.Second
 	LokiBaseURLFormat    = "https://%s"
 	lokiAPIV1PushPath    = "/loki/api/v1/push"

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	netv1 "k8s.io/api/networking/v1"
@@ -44,10 +45,11 @@ const (
 	AlloyEventsLoggerAppName      = "alloy-events"
 	AlloyEventsLoggerAppNamespace = "kube-system"
 
-	MaxBackoffPeriod  = "10m"
-	LokiBaseURLFormat = "https://%s"
-	lokiAPIV1PushPath = "/loki/api/v1/push"
-	LokiPushURLFormat = LokiBaseURLFormat + lokiAPIV1PushPath
+	LokiMaxBackoffPeriod = 10 * time.Minute
+	LokiRemoteTimeout    = 60 * time.Second
+	LokiBaseURLFormat    = "https://%s"
+	lokiAPIV1PushPath    = "/loki/api/v1/push"
+	LokiPushURLFormat    = LokiBaseURLFormat + lokiAPIV1PushPath
 
 	LoggingURL      = "logging-url"
 	LoggingTenantID = "logging-tenant-id"

--- a/pkg/resource/events-logger-config/alloy-events-config.go
+++ b/pkg/resource/events-logger-config/alloy-events-config.go
@@ -57,6 +57,7 @@ func generateAlloyConfig(lc loggedcluster.Interface, includeNamespaces []string,
 		Installation       string
 		InsecureSkipVerify string
 		MaxBackoffPeriod   string
+		RemoteTimeout      string
 		IncludeNamespaces  []string
 		ExcludeNamespaces  []string
 		SecretName         string
@@ -69,7 +70,8 @@ func generateAlloyConfig(lc loggedcluster.Interface, includeNamespaces []string,
 		ClusterID:          lc.GetClusterName(),
 		Installation:       lc.GetInstallationName(),
 		InsecureSkipVerify: fmt.Sprintf("%t", lc.IsInsecureCA()),
-		MaxBackoffPeriod:   common.MaxBackoffPeriod,
+		MaxBackoffPeriod:   common.LokiMaxBackoffPeriod.String(),
+		RemoteTimeout:      common.LokiRemoteTimeout.String(),
 		SecretName:         common.AlloyEventsLoggerAppName,
 		IncludeNamespaces:  includeNamespaces,
 		ExcludeNamespaces:  excludeNamespaces,

--- a/pkg/resource/events-logger-config/alloy/events-logger.alloy.template
+++ b/pkg/resource/events-logger-config/alloy/events-logger.alloy.template
@@ -39,6 +39,7 @@ loki.write "default" {
 	endpoint {
 		url                = nonsensitive(remote.kubernetes.secret.credentials.data["{{ .LoggingURLKey }}"])
 		max_backoff_period = "{{ .MaxBackoffPeriod }}"
+		remote_timeout     = "{{ .RemoteTimeout }}"
 		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["{{ .LoggingTenantIDKey }}"])
 
 		basic_auth {

--- a/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.MC.yaml
+++ b/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.MC.yaml
@@ -27,7 +27,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.WC.exclude-namespaces.yaml
+++ b/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.WC.exclude-namespaces.yaml
@@ -36,7 +36,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.WC.include-namespaces.yaml
+++ b/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.WC.include-namespaces.yaml
@@ -27,7 +27,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.WC.yaml
+++ b/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.WC.yaml
@@ -27,7 +27,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/events-logger-config/grafana-agent-config.go
+++ b/pkg/resource/events-logger-config/grafana-agent-config.go
@@ -59,6 +59,7 @@ func generateGrafanaAgentInnerConfig(lc loggedcluster.Interface, includeNamespac
 		ClusterID          string
 		Installation       string
 		InsecureSkipVerify string
+		RemoteTimeout      string
 		SecretName         string
 		IncludeNamespaces  []string
 		ExcludeNamespaces  []string
@@ -71,6 +72,7 @@ func generateGrafanaAgentInnerConfig(lc loggedcluster.Interface, includeNamespac
 		ClusterID:          lc.GetClusterName(),
 		Installation:       lc.GetInstallationName(),
 		InsecureSkipVerify: fmt.Sprintf("%t", lc.IsInsecureCA()),
+		RemoteTimeout:      common.LokiRemoteTimeout.String(),
 		SecretName:         eventsloggersecret.GetEventsLoggerSecretName(lc),
 		IncludeNamespaces:  includeNamespaces,
 		ExcludeNamespaces:  excludeNamespaces,

--- a/pkg/resource/events-logger-config/grafana-agent/events-logger.grafanaagent.template
+++ b/pkg/resource/events-logger-config/grafana-agent/events-logger.grafanaagent.template
@@ -37,6 +37,7 @@ loki.process "default" {
 loki.write "default" {
 	endpoint {
 		url                = nonsensitive(remote.kubernetes.secret.credentials.data["{{ .LoggingURLKey }}"])
+		remote_timeout     = "{{ .RemoteTimeout }}"
 		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["{{ .LoggingTenantIDKey }}"])
 
 		basic_auth {

--- a/pkg/resource/events-logger-config/grafana-agent/test/events-logger-config.grafanaagent.MC.yaml
+++ b/pkg/resource/events-logger-config/grafana-agent/test/events-logger-config.grafanaagent.MC.yaml
@@ -25,6 +25,7 @@ grafana-agent:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/events-logger-config/grafana-agent/test/events-logger-config.grafanaagent.WC.exclude-namespaces.yaml
+++ b/pkg/resource/events-logger-config/grafana-agent/test/events-logger-config.grafanaagent.WC.exclude-namespaces.yaml
@@ -34,6 +34,7 @@ grafana-agent:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/events-logger-config/grafana-agent/test/events-logger-config.grafanaagent.WC.include-namespaces.yaml
+++ b/pkg/resource/events-logger-config/grafana-agent/test/events-logger-config.grafanaagent.WC.include-namespaces.yaml
@@ -25,6 +25,7 @@ grafana-agent:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/events-logger-config/grafana-agent/test/events-logger-config.grafanaagent.WC.yaml
+++ b/pkg/resource/events-logger-config/grafana-agent/test/events-logger-config.grafanaagent.WC.yaml
@@ -25,6 +25,7 @@ grafana-agent:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/logging-config/alloy-logging-config.go
+++ b/pkg/resource/logging-config/alloy-logging-config.go
@@ -81,6 +81,7 @@ func generateAlloyConfig(lc loggedcluster.Interface, observabilityBundleVersion 
 		ClusterID          string
 		Installation       string
 		MaxBackoffPeriod   string
+		RemoteTimeout      string
 		IsWorkloadCluster  bool
 		SupportPodLogs     bool
 		InsecureSkipVerify bool
@@ -94,7 +95,8 @@ func generateAlloyConfig(lc loggedcluster.Interface, observabilityBundleVersion 
 	}{
 		ClusterID:         clusterName,
 		Installation:      lc.GetInstallationName(),
-		MaxBackoffPeriod:  common.MaxBackoffPeriod,
+		MaxBackoffPeriod:  common.LokiMaxBackoffPeriod.String(),
+		RemoteTimeout:     common.LokiRemoteTimeout.String(),
 		IsWorkloadCluster: common.IsWorkloadCluster(lc),
 		// Observability bundle in older versions do not support PodLogs
 		SupportPodLogs:     observabilityBundleVersion.GE(supportPodLogs),

--- a/pkg/resource/logging-config/alloy/logging.alloy.template
+++ b/pkg/resource/logging-config/alloy/logging.alloy.template
@@ -374,6 +374,7 @@ loki.write "default" {
 	endpoint {
 		url                = nonsensitive(remote.kubernetes.secret.credentials.data["{{ .LoggingURLKey }}"])
 		max_backoff_period = "{{ .MaxBackoffPeriod }}"
+		remote_timeout     = "{{ .RemoteTimeout }}"
 		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["{{ .LoggingTenantIDKey }}"])
 
 		basic_auth {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_MC.yaml
@@ -356,7 +356,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.162_WC.yaml
@@ -346,7 +346,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_MC.yaml
@@ -365,7 +365,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC.yaml
@@ -350,7 +350,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_custom_tenants.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_custom_tenants.yaml
@@ -390,7 +390,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_empty.yaml
@@ -350,7 +350,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
+++ b/pkg/resource/logging-config/alloy/test/logging-config.alloy.170_WC_default_namespaces_nil.yaml
@@ -350,7 +350,8 @@ alloy:
         loki.write "default" {
         	endpoint {
         		url                = nonsensitive(remote.kubernetes.secret.credentials.data["logging-url"])
-        		max_backoff_period = "10m"
+        		max_backoff_period = "10m0s"
+        		remote_timeout     = "1m0s"
         		tenant_id          = nonsensitive(remote.kubernetes.secret.credentials.data["logging-tenant-id"])
         
         		basic_auth {

--- a/pkg/resource/logging-secret/promtail-logging-secret.go
+++ b/pkg/resource/logging-secret/promtail-logging-secret.go
@@ -32,6 +32,7 @@ type promtailConfigClient struct {
 	BackoffConfig  promtailConfigClientBackoffConfig  `yaml:"backoff_config" json:"backoff_config"`
 	ExternalLabels promtailConfigClientExternalLabels `yaml:"external_labels" json:"external_labels"`
 	TLSConfig      promtailConfigClientTLSConfig      `yaml:"tls_config" json:"tls_config"`
+	Timeout        string                             `yaml:"timeout" json:"timeout"`
 }
 
 type promtailConfigClientTLSConfig struct {
@@ -71,12 +72,13 @@ func GeneratePromtailLoggingSecret(lc loggedcluster.Interface, credentialsSecret
 					{
 						URL:      fmt.Sprintf(common.LokiPushURLFormat, lokiURL),
 						TenantID: lc.GetTenant(),
+						Timeout:  common.LokiRemoteTimeout.String(),
 						BasicAuth: promtailConfigClientBasicAuth{
 							Username: writeUser,
 							Password: writePassword,
 						},
 						BackoffConfig: promtailConfigClientBackoffConfig{
-							MaxPeriod: common.MaxBackoffPeriod,
+							MaxPeriod: common.LokiMaxBackoffPeriod.String(),
 						},
 						ExternalLabels: promtailConfigClientExternalLabels{
 							Installation: lc.GetInstallationName(),


### PR DESCRIPTION
### What this PR does / why we need it

This pull request introduces changes to improve timeout configurations for `promtail`, `grafana-agent`, `alloy-events` and `alloy-logs` to better support larger installations. The updates include replacing string-based timeout values with `time.Duration` and adding a new `remote_timeout` parameter across multiple configurations and templates. Below is a summary of the most important changes grouped by theme.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure the new features are scoped to supported observability-bundle versions (see `supportPodLogs` boolean as an example).
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
