### PR TITLE
fix current finalizer left overs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix ongoing reconciliation issues where the logging-operator is always running on creation mode, even when a cluster is being deleted.
+
 ## [0.31.0] - 2025-09-17
 
 ### Added

--- a/pkg/resource/events-logger-config/reconciler.go
+++ b/pkg/resource/events-logger-config/reconciler.go
@@ -100,7 +100,7 @@ func (r *Resource) ReconcileDelete(ctx context.Context, cluster *capi.Cluster, l
 	err := r.Client.Get(ctx, types.NamespacedName{Name: getEventsLoggerConfigName(cluster, loggingAgent), Namespace: cluster.GetNamespace()}, &currentEventsLoggerConfig)
 	if err != nil {
 		if apimachineryerrors.IsNotFound(err) {
-			logger.Info("events-logger-config not found, stop here")
+			logger.Info("events-logger-config not found, nothing to delete")
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, errors.WithStack(err)

--- a/pkg/resource/logging-config/reconciler.go
+++ b/pkg/resource/logging-config/reconciler.go
@@ -98,7 +98,7 @@ func (r *Resource) ReconcileDelete(ctx context.Context, cluster *capi.Cluster, l
 	err := r.Client.Get(ctx, types.NamespacedName{Name: getLoggingConfigName(cluster), Namespace: cluster.GetNamespace()}, &currentLoggingConfig)
 	if err != nil {
 		if apimachineryerrors.IsNotFound(err) {
-			logger.Info("logging-config not found, stop here")
+			logger.Info("logging-config not found, nothing to delete")
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, errors.WithStack(err)


### PR DESCRIPTION
### What this PR does / why we need it

In a recent refactoring, the logging operator was stuck in logging enabled mode and never tried to clean up resources nor it's finalizer when a cluster CR is being deleted.

This is fixing this

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure the new features are scoped to supported observability-bundle versions (see `supportPodLogs` boolean as an example).
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
