### PR TITLE
Remove tenant cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added feature flags to disable alloy events and alloy logs reconciliations.
+
+### Changed
+
+- Remove the clean up of the giantswarm.tenant resource attribute in traces so we can count the number of unique trace datasources (https://github.com/giantswarm/roadmap/issues/4024)
+
+### Fixed
+
+- Fix tests templates for alloy-events (due to incorrect ClusterLabels).
+
 ### Removed
 
 - Remove unused credentials reconcilers.

--- a/pkg/resource/events-logger-config/alloy/events-logger.alloy.template
+++ b/pkg/resource/events-logger-config/alloy/events-logger.alloy.template
@@ -134,22 +134,6 @@ otelcol.processor.filter "{{ . }}" {
 		]
 	}
 	output {
-		traces = [otelcol.processor.transform.cleanup_{{ . }}.input]
-	}
-}
-
-// Remove giantswarm.tenant resource attribute after filtering
-otelcol.processor.transform "cleanup_{{ . }}" {
-	error_mode = "ignore"
-
-	trace_statements {
-		context = "resource"
-		statements = [
-			`delete_key(resource.attributes, "giantswarm.tenant")`,
-		]
-	}
-
-	output {
 		traces = [otelcol.exporter.otlp.{{ . }}.input]
 	}
 }

--- a/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.MC.tracing-enabled.yaml
+++ b/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.MC.tracing-enabled.yaml
@@ -115,19 +115,6 @@ alloy:
         		]
         	}
         	output {
-        		traces = [otelcol.processor.transform.cleanup_giantswarm.input]
-        	}
-        }
-        // Remove giantswarm.tenant resource attribute after filtering
-        otelcol.processor.transform "cleanup_giantswarm" {
-        	error_mode = "ignore"
-        	trace_statements {
-        		context = "resource"
-        		statements = [
-        			`delete_key(resource.attributes, "giantswarm.tenant")`,
-        		]
-        	}
-        	output {
         		traces = [otelcol.exporter.otlp.giantswarm.input]
         	}
         }

--- a/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.WC.tracing-enabled.yaml
+++ b/pkg/resource/events-logger-config/alloy/test/events-logger-config.alloy.WC.tracing-enabled.yaml
@@ -115,19 +115,6 @@ alloy:
         		]
         	}
         	output {
-        		traces = [otelcol.processor.transform.cleanup_giantswarm.input]
-        	}
-        }
-        // Remove giantswarm.tenant resource attribute after filtering
-        otelcol.processor.transform "cleanup_giantswarm" {
-        	error_mode = "ignore"
-        	trace_statements {
-        		context = "resource"
-        		statements = [
-        			`delete_key(resource.attributes, "giantswarm.tenant")`,
-        		]
-        	}
-        	output {
         		traces = [otelcol.exporter.otlp.giantswarm.input]
         	}
         }


### PR DESCRIPTION
### What this PR does / why we need it

Removes the tenant clean up from the trace resource attribute so we can count the number of individual trace sources towards https://github.com/giantswarm/roadmap/issues/4024

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure the new features are scoped to supported observability-bundle versions (see `supportPodLogs` boolean as an example).
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
